### PR TITLE
feat: sentry release integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
   - [pytest](#pytest)
   - [utils](#utils)
   - [npm-audit](#npm-audit)
+  - [sentry](#sentry)
 - [Developing Orbs](#developing-orbs)
 - [Publishing Orbs](#publishing-orbs)
 
@@ -58,6 +59,10 @@ This orb provides utility functions such as status badging, file uploads, and ss
 ### npm-audit
 
 Provides functionality to generate npm audit reports and e-mail failure reports. For information on configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm-audit).
+
+### sentry
+
+Publish releases to Sentry. For information on configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry).
 
 ## Developing Orbs
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,14 @@ Provides functionality to generate npm audit reports and e-mail failure reports.
 
 ### sentry
 
-Publish releases to Sentry. For information on configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry).
+Publish releases to [Sentry](https://sentry.io/). Note that the `create_release` jobs uses the following defaults when creating releases:
+
+-   The Sentry organisation slug is assumed to be identical to the CI organisation.
+-   The project slug is assumed to be the same as the repository name.
+-   The release version is taken from the tag name.
+-   It is assumed that repositories have been configured within the Sentry organization so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).
+
+For information on how to override these defaults, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry). An [example configuration](/examples/sentry.yml) is provided in the [examples folder](/examples/).
 
 ## Developing Orbs
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Provides functionality to generate npm audit reports and e-mail failure reports.
 
 ### sentry
 
-Publish releases to [Sentry](https://sentry.io/). Note that the `create_release` jobs uses the following defaults when creating releases:
+Publish releases to [Sentry](https://sentry.io/). Note that the `create_release` job uses the following defaults when creating releases:
 
 -   The Sentry organisation slug is assumed to be identical to the CI organisation.
 -   The project slug is assumed to be the same as the repository name.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Provides functionality to generate npm audit reports and e-mail failure reports.
 
 Publish releases to [Sentry](https://sentry.io/). Note that the `create_release` job uses the following defaults when creating releases:
 
--   The Sentry organisation slug is assumed to be identical to the CI organisation.
 -   The project slug is assumed to be the same as the repository name.
 -   The release version is taken from the tag name.
 -   It is assumed that repositories have been configured within the Sentry organisation so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Publish releases to [Sentry](https://sentry.io/). Note that the `create_release`
 -   The Sentry organisation slug is assumed to be identical to the CI organisation.
 -   The project slug is assumed to be the same as the repository name.
 -   The release version is taken from the tag name.
--   It is assumed that repositories have been configured within the Sentry organization so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).
+-   It is assumed that repositories have been configured within the Sentry organisation so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).
 
 For information on how to override these defaults, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry). An [example configuration](/examples/sentry.yml) is provided in the [examples folder](/examples/).
 

--- a/examples/sentry.yml
+++ b/examples/sentry.yml
@@ -1,0 +1,33 @@
+version: 2.1
+orbs:
+    sentry: arrai/sentry@1.0.0
+executors:
+    base:
+        docker:
+            - image: cimg/base:latest
+jobs:
+    test:
+        executor: base
+        steps:
+            - checkout
+workflows:
+    test_and_release:
+        jobs:
+            - test:
+                  name: tests
+                  context: arrai-global
+                  filters:
+                      branches:
+                          only: /.*/
+                      tags:
+                          only: /.*/
+            - sentry/create_release:
+                  name: release
+                  context: arrai-global
+                  requires:
+                      - tests
+                  filters:
+                      tags:
+                          only: /.*/
+                      branches:
+                          ignore: /.*/

--- a/sentry.yml
+++ b/sentry.yml
@@ -1,0 +1,88 @@
+version: 2.1
+orbs:
+    utils: arrai/utils@1.8.0
+executors:
+    base:
+        docker:
+            - image: cimg/base:current
+jobs:
+    create_release:
+        parameters:
+            executor:
+                description: "The executor to use for the job."
+                type: executor
+                default: base
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+                default: small
+            sentry_org:
+                description: "The Sentry organization slug."
+                type: string
+                default: ${SENTRY_ORG}
+            sentry_project:
+                description: "The Sentry project slug."
+                type: string
+                default: ${CIRCLE_PROJECT_REPONAME}
+            sentry_release:
+                description: "The version for the Sentry release."
+                type: string
+                default: ${CIRCLE_TAG}
+            sentry_commit_integration:
+                description: "From where to pull commit information."
+                type: enum
+                enum: [auto, local]
+                default: auto
+            setup:
+                description: "Any additional setup steps."
+                type: steps
+                default:
+                    - run:
+                          name: Install Sentry CLI Tools
+                          command: |
+                              curl -sL https://sentry.io/get-cli/ | bash
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        steps:
+            - checkout
+            - steps: <<parameters.setup>>
+            - create_release:
+                  sentry_org: <<parameters.sentry_org>>
+                  sentry_project: <<parameters.sentry_project>>
+                  sentry_release: <<parameters.sentry_release>>
+                  sentry_commit_integration: <<parameters.sentry_commit_integration>>
+commands:
+    create_release:
+        description: "Create release on Sentry."
+        parameters:
+            sentry_org:
+                description: "The Sentry organization slug."
+                type: string
+                default: ${SENTRY_ORG}
+            sentry_project:
+                description: "The Sentry project slug."
+                type: string
+                default: ${CIRCLE_PROJECT_REPONAME}
+            sentry_release:
+                description: "The version for the Sentry release."
+                type: string
+                default: ${CIRCLE_TAG}
+            sentry_commit_integration:
+                description: "From where to pull commit information."
+                type: enum
+                enum: ["auto", "local"]
+                default: auto
+        steps:
+            - run:
+                  command: |
+                      export SENTRY_ORG="<<parameters.sentry_org>>"
+                      export SENTRY_PROJECT="<<parameters.sentry_project>>"
+                      export SENTRY_RELEASE="<<parameters.sentry_release>>"
+                      sentry-cli releases new ${SENTRY_RELEASE}
+                      if [ "${<<parameters.sentry_commit_integration>>}" = "local" ]; then
+                          sentry-cli releases set-commits ${SENTRY_RELEASE} --local --initial-depth 9223372036854775807
+                      else
+                          sentry-cli releases set-commits ${SENTRY_RELEASE} --auto
+                      fi
+                      sentry-cli releases finalize ${SENTRY_RELEASE}


### PR DESCRIPTION
New orb to add releases to Sentry. Published as `arrai/sentry@1.0.0`