### PR TITLE
feat: pypi integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
   - [utils](#utils)
   - [npm-audit](#npm-audit)
   - [sentry](#sentry)
+  - [pypi](#pypi)
 - [Developing Orbs](#developing-orbs)
 - [Publishing Orbs](#publishing-orbs)
 
@@ -69,6 +70,12 @@ Publish releases to [Sentry](https://sentry.io/). Note that the `create_release`
 -   It is assumed that repositories have been configured within the Sentry organisation so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).
 
 For information on how to override these defaults, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry). An [example configuration](/examples/sentry.yml) is provided in the [examples folder](/examples/).
+
+### pypi
+
+Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and persists the dist folder to the workspace. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
+
+For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pypi).
 
 ## Developing Orbs
 

--- a/examples/pypi.yml
+++ b/examples/pypi.yml
@@ -1,0 +1,55 @@
+version: 2.1
+orbs:
+    pypi: arrai/pypi@1.0.0
+executors:
+    python310:
+        docker:
+            - image: cimg/python:3.10
+jobs:
+    test:
+        executor: python310
+        resource_class: small
+        steps:
+            - checkout
+    build:
+        executor: python310
+        resource_class: small
+        steps:
+            - checkout
+            - run:
+                  name: Build Package
+                  command: |
+                      python setup.py sdist bdist_wheel
+            - persist_to_workspace:
+                  root: ./
+                  paths:
+                      - dist
+workflows:
+    test_and_release:
+        jobs:
+            - test:
+                  name: tests
+                  filters:
+                      branches:
+                          only: /.*/
+                      tags:
+                          only: /.*/
+            - build:
+                  name: build
+                  requires:
+                      - tests
+                  filters:
+                      tags:
+                          only: /.*/
+                      branches:
+                          ignore: /.*/
+            - pypi/upload_release:
+                  name: release
+                  context: arrai-private-package-publishing
+                  requires:
+                      - build
+                  filters:
+                      tags:
+                          only: /.*/
+                      branches:
+                          ignore: /.*/

--- a/pypi.yml
+++ b/pypi.yml
@@ -1,0 +1,85 @@
+version: 2.1
+description: Helper for uploading python packages to repositories.
+orbs:
+    utils: arrai/utils@1.8.0
+executors:
+    python310:
+        docker:
+            - image: cimg/python:3.10
+        environment:
+            TWINE_NON_INTERACTIVE: 1
+jobs:
+    upload_release:
+        parameters:
+            executor:
+                description: "The executor to use for the job."
+                type: executor
+                default: python310
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+                default: small
+            twine_username:
+                description: "The username to use for authentication to the repository."
+                type: string
+                default: ${TWINE_USERNAME}
+            twine_password:
+                description: "The password to use for authentication to the repository."
+                type: string
+                default: ${TWINE_PASSWORD}
+            twine_repository_url:
+                description: "The URL of the repository to upload to."
+                type: string
+                default: ${TWINE_REPOSITORY_URL}
+            setup:
+                description: "Any additional setup steps."
+                type: steps
+                default:
+                    - run:
+                          name: Install Twine
+                          command: |
+                              pip install twine
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        steps:
+            - checkout
+            - steps: <<parameters.setup>>
+            - attach_workspace:
+                  at: ./
+            - check
+            - upload:
+                  twine_username: <<parameters.twine_username>>
+                  twine_password: <<parameters.twine_password>>
+                  twine_repository_url: <<parameters.twine_repository_url>>
+commands:
+    check:
+        description: "Checks whether the long description will render correctly on PyPI."
+        steps:
+            - run:
+                  name: "Check that the long description renders correctly."
+                  command: |
+                      twine check --strict ./dist/*
+    upload:
+        description: "Upload packages to the repository."
+        parameters:
+            twine_username:
+                description: "The username to use for authentication to the repository."
+                type: string
+                default: ${TWINE_USERNAME}
+            twine_password:
+                description: "The password to use for authentication to the repository."
+                type: string
+                default: ${TWINE_PASSWORD}
+            twine_repository_url:
+                description: "The URL of the repository to upload to."
+                type: string
+                default: ${TWINE_REPOSITORY_URL}
+        steps:
+            - run:
+                  name: "Upload packages to the repository."
+                  command: |
+                      export TWINE_USERNAME="<<parameters.twine_username>>"
+                      export TWINE_PASSWORD="<<parameters.twine_password>>"
+                      export TWINE_REPOSITORY_URL="<<parameters.twine_repository_url>>"
+                      twine upload ./dist/*

--- a/pypi.yml
+++ b/pypi.yml
@@ -47,35 +47,10 @@ jobs:
             - steps: <<parameters.setup>>
             - attach_workspace:
                   at: ./
-            - check
-            - upload:
-                  twine_username: <<parameters.twine_username>>
-                  twine_password: <<parameters.twine_password>>
-                  twine_repository_url: <<parameters.twine_repository_url>>
-commands:
-    check:
-        description: "Checks whether the long description will render correctly on PyPI."
-        steps:
             - run:
                   name: "Check that the long description renders correctly."
                   command: |
                       twine check --strict ./dist/*
-    upload:
-        description: "Upload packages to the repository."
-        parameters:
-            twine_username:
-                description: "The username to use for authentication to the repository."
-                type: string
-                default: ${TWINE_USERNAME}
-            twine_password:
-                description: "The password to use for authentication to the repository."
-                type: string
-                default: ${TWINE_PASSWORD}
-            twine_repository_url:
-                description: "The URL of the repository to upload to."
-                type: string
-                default: ${TWINE_REPOSITORY_URL}
-        steps:
             - run:
                   name: "Upload packages to the repository."
                   command: |


### PR DESCRIPTION
Add new orb to simplify publishing of packages to pypi and compatible repos.
Published as [arrai/pypi@1.0.0](https://circleci.com/developer/orbs/orb/arrai/pypi?version=1.0.0)