### PR TITLE
fix: default to python 3.8

### DIFF
--- a/flake8.yml
+++ b/flake8.yml
@@ -36,7 +36,7 @@ jobs:
             executor:
                 description: "The executor to use for the job."
                 type: executor
-                default: python36
+                default: python38
             resource_class:
                 description: "The resource class to use for the job."
                 type: enum


### PR DESCRIPTION
Published as [arrai/flake8@13.1.0](https://circleci.com/developer/orbs/orb/arrai/flake8?version=13.1.0)