### PR TITLE
make npm audit results email optional

### DIFF
--- a/npm.yml
+++ b/npm.yml
@@ -87,7 +87,6 @@ jobs:
         resource_class: <<parameters.resource_class>>
         steps:
             - checkout
-            - utils/add_ssh_config
             - steps: <<parameters.setup>>
             - upgrade_npm
             - utils/add_npm_config
@@ -111,6 +110,7 @@ jobs:
             - when:
                   condition: <<parameters.create_badges>>
                   steps:
+                      - utils/add_ssh_config
                       - run:
                             name: "Count vulnerabilities"
                             when: on_fail

--- a/npm.yml
+++ b/npm.yml
@@ -74,6 +74,7 @@ jobs:
             report_to:
                 description: "E-mail address to send npm audit failure report to."
                 type: string
+                default: ""
             skip_dev:
                 description: "Don't check development dependencies."
                 type: boolean
@@ -99,11 +100,14 @@ jobs:
                   name: "Generate HTML audit report"
                   when: on_fail
                   command: cat ${HOME}/audit.log | ansi2html > ${HOME}/audit.html
-            - utils/send_email:
-                  when: on_fail
-                  to: <<parameters.report_to>>
-                  subject: "npm audit report for ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
-                  html: "<${HOME}/audit.html"
+            - when:
+                  condition: <<parameters.report_to>>
+                  steps:
+                      - utils/send_email:
+                            when: on_fail
+                            to: <<parameters.report_to>>
+                            subject: "npm audit report for ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
+                            html: "<${HOME}/audit.html"
             - when:
                   condition: <<parameters.create_badges>>
                   steps:

--- a/npm.yml
+++ b/npm.yml
@@ -21,12 +21,12 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:14.19
+            - image: cimg/node:14.20
     v16:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:16.15
+            - image: cimg/node:16.16
     v17:
         environment:
             LANG: en_US.UTF-8
@@ -36,7 +36,7 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.2
+            - image: cimg/node:18.7
 commands:
     upgrade_npm:
         steps:

--- a/npm.yml
+++ b/npm.yml
@@ -87,6 +87,7 @@ jobs:
         resource_class: <<parameters.resource_class>>
         steps:
             - checkout
+            - utils/add_ssh_config
             - steps: <<parameters.setup>>
             - upgrade_npm
             - utils/add_npm_config
@@ -110,7 +111,6 @@ jobs:
             - when:
                   condition: <<parameters.create_badges>>
                   steps:
-                      - utils/add_ssh_config
                       - run:
                             name: "Count vulnerabilities"
                             when: on_fail

--- a/npm.yml
+++ b/npm.yml
@@ -176,7 +176,6 @@ jobs:
         steps:
             - checkout
             - utils/add_ssh_config
-            - checkout
             - steps: <<parameters.setup>>
             - upgrade_npm
             - utils/add_npm_config


### PR DESCRIPTION
Published as [arrai/npm@2.6.0](https://circleci.com/developer/orbs/orb/arrai/npm?version=2.6.0)

- make `report_to` parameter optional and skip audit email if unset
- bumped node minor releases where applicable