### PR TITLE
feat: allow spaces in job names

### DIFF
--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -221,7 +221,8 @@ commands:
                           if [ "${MATCH}" -gt "0" ]; then
                               OLD_LANG="${LANG}"
                               LANG=en_US.UTF-8
-                              rsync -t -e "ssh" <<parameters.file>> "<<parameters.host>>:/<<parameters.remote_file>>"
+                              REMOTE_FILE=$(printf %q "<<parameters.remote_file>>")
+                              rsync -t -e "ssh" <<parameters.file>> "<<parameters.host>>:/${REMOTE_FILE}"
                               LANG="${OLD_LANG}"
                           fi
                       fi
@@ -267,7 +268,8 @@ commands:
                           if [ "${MATCH}" -gt "0" ]; then
                               OLD_LANG="${LANG}"
                               LANG=en_US.UTF-8
-                              rsync <<# parameters.delete>>--delete<</ parameters.delete>> -r -l -t -e "ssh" <<parameters.folder>> "<<parameters.host>>:/<<parameters.remote_folder>>"
+                              REMOTE_FOLDER=$(printf %q "<<parameters.remote_folder>>")
+                              rsync <<# parameters.delete>>--delete<</ parameters.delete>> -r -l -t -e "ssh" <<parameters.folder>> "<<parameters.host>>:/${REMOTE_FOLDER}"
                               LANG="${OLD_LANG}"
                           fi
                       fi

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -183,7 +183,7 @@ commands:
                       COLORS=(["95"]="brightgreen" ["90"]="green" ["75"]="yellowgreen" ["60"]="yellow" ["40"]="orange" ["0"]="red")
                       VALUES=("95" "90" "75" "60" "40" "0");
                       for KEY in "${VALUES[@]}"; do if [ "${COVERAGE_PERCENTAGE}" -ge "$KEY" ]; then COVERAGE_COLOR=${COLORS[$KEY]}; break; fi; done;
-                      curl -sS -o <<parameters.file>> "https://img.shields.io/badge/Coverage-${COVERAGE_PERCENTAGE}%25-${COVERAGE_COLOR}.svg?logo=<<parameters.logo>>&logoColor=white&style=<<parameters.style>>&link=<<parameters.link>>"
+                      curl --get --data-urlencode "link=<<parameters.link>>" -sS -o <<parameters.file>> "https://img.shields.io/badge/Coverage-${COVERAGE_PERCENTAGE}%25-${COVERAGE_COLOR}.svg?logo=<<parameters.logo>>&logoColor=white&style=<<parameters.style>>"
                   when: <<parameters.when>>
     rsync_file:
         description: "Copy a single file to a remote destination via rsync."

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -135,7 +135,8 @@ commands:
             - run:
                   name: Make status shield (<<parameters.status>>)
                   command: |
-                      <<# parameters.preserve>>[ ! -f <<parameters.file>> ] && <</ parameters.preserve>> curl -sS -o <<parameters.file>> "https://img.shields.io/badge/<<parameters.label>>-<<parameters.status>>-<<parameters.color>>.svg?logo=<<parameters.logo>>&logoColor=white&style=<<parameters.style>>&link=${CIRCLE_BUILD_URL}" || :
+                      LABEL=$(echo -n "<<parameters.label>>" | sed -e 's/ /_/g' -e 's/-/--/g')
+                      <<# parameters.preserve>>[ ! -f <<parameters.file>> ] && <</ parameters.preserve>> curl -sS -o <<parameters.file>> "https://img.shields.io/badge/${LABEL}-<<parameters.status>>-<<parameters.color>>.svg?logo=<<parameters.logo>>&logoColor=white&style=<<parameters.style>>&link=${CIRCLE_BUILD_URL}" || :
                   when: <<parameters.when>>
     make_coverage_shield:
         description: "Fetch coverage shield from shields.io."


### PR DESCRIPTION
rsync uploads and shields.io badge generation should now work with job names that contain spaces. The circleci documentation implies that this is not supported, however, it does seem to work... I can't recommend actually doing this as there are probably tons of edge cases where this breaks. Nonetheless, we've added some compatibility here. This has been published as arrai/utils@1.12.0.