### PR TITLE
fix: make resource_class mandatory

### DIFF
--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -27,7 +27,6 @@ jobs:
                 description: "The resource class to use for the job."
                 type: enum
                 enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: medium
             parallel:
                 description: "The level of test parallelism."
                 type: integer
@@ -136,7 +135,6 @@ jobs:
                 description: "The resource class to use for the job."
                 type: enum
                 enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: medium
             badge_label:
                 description: "The label to use for the badge."
                 type: string
@@ -205,7 +203,6 @@ jobs:
                 description: "The resource class to use for the job."
                 type: enum
                 enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: medium
             parallel:
                 description: "The level of test parallelism."
                 type: integer
@@ -291,7 +288,6 @@ jobs:
                 description: "The resource class to use for the job."
                 type: enum
                 enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
             setup:
                 description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
                 type: steps


### PR DESCRIPTION
Defaulting to `medium` had the unintended consequence of overriding the `resource_class` specified on the passed-in executor as the job level `resource_class` is of higher priority. Unfortunately there is not a way to have a truly optional parameter; it's either required or must have a default.