### PR TITLE
chore: bump to latest nodejs releases

### DIFF
--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -131,14 +131,19 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:14.19
+            - image: cimg/node:14.21.3
     v16:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:16.15
+            - image: cimg/node:16.20
     v18:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.2
+            - image: cimg/node:18.16
+    v20:
+        environment:
+            LANG: en_US.UTF-8
+        docker:
+            - image: cimg/node:20.0

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -21,22 +21,22 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:14.20
+            - image: cimg/node:14.21.3
     v16:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:16.16
-    v17:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:17.9
+            - image: cimg/node:16.20
     v18:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.7
+            - image: cimg/node:18.16
+    v20:
+        environment:
+            LANG: en_US.UTF-8
+        docker:
+            - image: cimg/node:20.0
 commands:
     upgrade_npm:
         steps:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -6,7 +6,7 @@ executors:
         environment:
             LANG: C.UTF-8
         docker:
-            - image: cimg/node:16.19.1-browsers
+            - image: cimg/node:16.20.0-browsers
 jobs:
     code_style:
         parameters:


### PR DESCRIPTION
Published as `arrai/eslint@7.5.0`, `arrai/npm@2.7.0`, and `arrai/prettier@5.3.0`