### PR TITLE
chore: bump node versions

### DIFF
--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -26,7 +26,7 @@ jobs:
             executor:
                 description: "The executor to use for the job."
                 type: executor
-                default: v16
+                default: v18
             resource_class:
                 description: "The resource class to use for the job."
                 type: enum

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -124,14 +124,14 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:16.20
+            - image: cimg/node:16.20.2
     v18:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.16
+            - image: cimg/node:18.17.1
     v20:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:20.0
+            - image: cimg/node:20.5.1

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -26,17 +26,17 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:16.20
+            - image: cimg/node:16.20.2
     v18:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.16
+            - image: cimg/node:18.17.1
     v20:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:20.0
+            - image: cimg/node:20.5.1
 commands:
     upgrade_npm:
         steps:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -2,11 +2,11 @@ version: 2.1
 orbs:
     utils: arrai/utils@1.12.0
 executors:
-    node16:
+    node18:
         environment:
             LANG: C.UTF-8
         docker:
-            - image: cimg/node:16.20.0-browsers
+            - image: cimg/node:18.17.1-browsers
 jobs:
     code_style:
         parameters:
@@ -17,7 +17,7 @@ jobs:
             executor:
                 description: "The executor to use for the job."
                 type: executor
-                default: node16
+                default: node18
             resource_class:
                 description: "The resource class to use for the job."
                 type: enum


### PR DESCRIPTION
- bump defaults to node 18; node 16 is EOL September 11th
- bump minimum version of node 18 as npm 10 doesn't support < 18.17