### PR TITLE
feat: allow configurable cache key

### DIFF
--- a/orbs/pypi.yml
+++ b/orbs/pypi.yml
@@ -45,7 +45,6 @@ jobs:
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         steps:
-            - checkout
             - steps: <<parameters.setup>>
             - restore_cache:
                   keys:

--- a/orbs/pypi.yml
+++ b/orbs/pypi.yml
@@ -30,6 +30,10 @@ jobs:
                 description: "The URL of the repository to upload to."
                 type: string
                 default: ${TWINE_REPOSITORY_URL}
+            cache_key:
+                description: "Key used to restore build cache."
+                type: string
+                default: build-{{ checksum "/etc/os-release" }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
             setup:
                 description: "Any additional setup steps."
                 type: steps
@@ -45,7 +49,7 @@ jobs:
             - steps: <<parameters.setup>>
             - restore_cache:
                   keys:
-                      - build-{{ checksum "/etc/os-release" }}-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                      - <<parameters.cache_key>>
             - run:
                   name: "Check that the long description renders correctly."
                   command: |


### PR DESCRIPTION
The key used to restore the cache was unconfigurable and based on the OS release. In cases where a custom executor is used as part of the build process, that executor is then required to be used as part of the publish process, which doesn't make much sense; the publisher only needs to upload an already built wheel to the pypi server.

- allow for a cache key to be specified via the `cache_key` parameter; default to the current implementation
- don't check out the source tree from the repo; it's not required here.

Published as `arrai/pypi@3.1.0`
