### PR TITLE
docs: update pypi publish information & example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For information on how to override these defaults, refer to the generated [docum
 
 ### pypi
 
-Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and persists the dist folder to the workspace. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
+Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and stashes the dist folder in a cache. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
 
 For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pypi).
 

--- a/examples/pypi.yml
+++ b/examples/pypi.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    pypi: arrai/pypi@1.0.0
+    pypi: arrai/pypi@3.1.0
 executors:
     python310:
         docker:
@@ -20,10 +20,10 @@ jobs:
                   name: Build Package
                   command: |
                       python setup.py sdist bdist_wheel
-            - persist_to_workspace:
-                  root: ./
+            - save_cache:
                   paths:
-                      - dist
+                      - ~/project/dist
+                  key: build-{{ .Environment.CIRCLE_WORKFLOW_ID }}
 workflows:
     test_and_release:
         jobs:
@@ -45,6 +45,7 @@ workflows:
                           ignore: /.*/
             - pypi/upload_release:
                   name: release
+                  cache_key: build-{{ .Environment.CIRCLE_WORKFLOW_ID }}
                   context: arrai-private-package-publishing
                   requires:
                       - build


### PR DESCRIPTION
As of version 2+ of the pypi orb, it's expected that the build files are stored to cache rather than be persisted to the workspace. Update the README and example to reflect that.