### PR TITLE
feat: allow optional use of fixed ip ranges

### DIFF
--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.11.0
+    utils: arrai/utils@1.13.0
 jobs:
     badass:
         parameters:

--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,210 +1,253 @@
 version: 2.1
 orbs:
     utils: arrai/utils@1.13.0
+aliases:
+    common_parameters: &common_parameters
+        wd:
+            description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
+            type: string
+            default: ${CIRCLE_PROJECT_REPONAME}
+        setup:
+            description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+            type: steps
+            default: []
+        executor:
+            description: "Execution environment for the test job."
+            type: executor
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+    common_badass_parameters: &common_badass_parameters
+        <<: *common_parameters
+        repodir:
+            description: "Location of the git repo (no trailing slash)."
+            type: string
+            default: ~/project
+        config:
+            description: "Any additional BMS configuration steps."
+            type: steps
+            default: []
+        parallel:
+            description: "The level of test parallelism."
+            type: integer
+            default: 4
+        badge_label:
+            description: "The label to use for the badge."
+            type: string
+            default: tests
+        meta_job_name:
+            description: "The filename to use for the badge."
+            type: string
+        test_script:
+            description: "The test script to run (e.g., manage.py test)."
+            type: string
+            default: manage.py test
+        pipenv_python_arg:
+            description: "Location or version of the python interpreter to use for pipenv."
+            type: string
+            default: ""
+        pipenv_skip_lock:
+            description: "Skip use of the pipenv lock file."
+            type: boolean
+            default: false
+    common_badass_steps: &common_badass_steps
+        - checkout
+        - utils/add_maxmind_config
+        - utils/add_ssh_config
+        - utils/make_status_shield:
+              status: running
+              color: lightblue
+              file: ~/status.svg
+              label: <<parameters.badge_label>>
+        - utils/rsync_file:
+              file: ~/status.svg
+              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+              host: docs
+        - steps: <<parameters.setup>>
+        - setup_pipenv:
+              pipenv_python_arg: <<parameters.pipenv_python_arg>>
+              pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
+        - setup_badass_config:
+              wd: <<parameters.wd>>
+        - steps: <<parameters.config>>
+        - run_tests:
+              wd: <<parameters.wd>>
+              parallel: <<parameters.parallel>>
+              test_script: <<parameters.test_script>>
+        - coverage_combine_and_html:
+              wd: <<parameters.wd>>
+        - store_test_results:
+              path: test-results
+        - store_artifacts:
+              path: test-results
+              destination: tr1
+        - utils/rsync_folder:
+              when: always
+              folder: <<parameters.wd>>/htmlcov/
+              remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
+              host: docs
+        - utils/make_coverage_shield:
+              when: always
+              link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
+        - utils/rsync_file:
+              when: always
+              file: /tmp/coverage.svg
+              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
+              host: docs
+        - utils/make_status_shield:
+              when: on_success
+              status: passed
+              color: brightgreen
+              file: ~/status.svg
+              label: <<parameters.badge_label>>
+        - utils/make_status_shield:
+              when: on_fail
+              status: failed
+              color: red
+              file: ~/status.svg
+              label: <<parameters.badge_label>>
+        - utils/rsync_file:
+              when: always
+              file: ~/status.svg
+              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+              host: docs
+    common_badass_pre_spread_parameters: &common_badass_pre_spread_parameters
+        <<: *common_parameters
+        config:
+            description: "Any additional BMS configuration steps."
+            type: steps
+            default: []
+        badge_label:
+            description: "The label to use for the badge."
+            type: string
+            default: tests
+        meta_job_name:
+            description: "The filename to use for the badge."
+            type: string
+        pipenv_python_arg:
+            description: "Location or version of the python interpreter to use for pipenv."
+            type: string
+            default: ""
+        pipenv_skip_lock:
+            description: "Skip use of the pipenv lock file."
+            type: boolean
+            default: false
+        pipenv_cache_key_version:
+            description: "a string that can be changed to bust the pipenv cache."
+            type: string
+            default: "1"
+    common_badass_pre_spread_steps: &common_badass_pre_spread_steps
+        - checkout
+        - utils/add_ssh_config
+        - utils/make_status_shield:
+              status: running
+              color: lightblue
+              file: ~/status.svg
+              label: <<parameters.badge_label>>
+        - utils/rsync_file:
+              file: ~/status.svg
+              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+              host: docs
+        - steps: <<parameters.setup>>
+        - restore_cache:
+              keys:
+                  - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+                  - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
+                  - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-main
+        - setup_pipenv:
+              pipenv_python_arg: <<parameters.pipenv_python_arg>>
+              pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
+        - save_cache:
+              paths:
+                  - ~/.local/share/virtualenvs
+              key: pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+        - steps: <<parameters.config>>
+        - persist_to_workspace:
+              root: ~/
+              paths:
+                  - .local/share/virtualenvs
+    common_badass_test_combine: &common_badass_test_combine
+        - checkout
+        - steps: <<parameters.setup>>
+        - utils/add_ssh_config
+        - attach_workspace:
+              at: ~/
+        - run:
+              name: Restore workspace files
+              command: |
+                  shopt -s dotglob
+                  cp ~/workspace/* <<parameters.wd>>/
+        - run:
+              name: Combine status
+              command: |
+                  if [ $(cat <<parameters.wd>>/0.status) -eq "0" ]; then
+                      diff -q --from-file <<parameters.wd>>/*.status && touch /tmp/passed
+                  fi
+        - utils/make_status_shield:
+              status: $([ -f /tmp/passed ] && echo "passed" || echo "failed")
+              color: $([ -f /tmp/passed ] && echo "brightgreen" || echo "red")
+              file: /tmp/status.svg
+              label: <<parameters.badge_label>>
+        - utils/rsync_file:
+              when: always
+              file: /tmp/status.svg
+              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+              host: docs
+        - coverage_combine_and_html:
+              wd: <<parameters.wd>>
+        - utils/rsync_folder:
+              when: always
+              folder: <<parameters.wd>>/htmlcov/
+              remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
+              host: docs
+        - utils/make_coverage_shield:
+              when: always
+              file: /tmp/coverage.svg
+              link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
+        - utils/rsync_file:
+              when: always
+              file: /tmp/coverage.svg
+              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
+              host: docs
 jobs:
     badass:
         parameters:
-            repodir:
-                description: "Location of the git repo (no trailing slash)."
-                type: string
-                default: ~/project
-            wd:
-                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
-                type: string
-                default: ${CIRCLE_PROJECT_REPONAME}
-            setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
-                type: steps
-                default: []
-            config:
-                description: "Any additional BMS configuration steps."
-                type: steps
-                default: []
-            executor:
-                description: "Execution environment for the test job."
-                type: executor
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-            parallel:
-                description: "The level of test parallelism."
-                type: integer
-                default: 4
-            badge_label:
-                description: "The label to use for the badge."
-                type: string
-                default: tests
-            meta_job_name:
-                description: "The filename to use for the badge."
-                type: string
-            test_script:
-                description: "The test script to run (e.g., manage.py test)."
-                type: string
-                default: manage.py test
-            pipenv_python_arg:
-                description: "Location or version of the python interpreter to use for pipenv."
-                type: string
-                default: ""
-            pipenv_skip_lock:
-                description: "Skip use of the pipenv lock file."
-                type: boolean
-                default: false
+            <<: *common_badass_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        working_directory: <<parameters.repodir>>
+        steps: *common_badass_steps
+    badass_fixed_ip:
+        parameters:
+            <<: *common_badass_parameters
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
         working_directory: <<parameters.repodir>>
-        steps:
-            - checkout
-            - utils/add_maxmind_config
-            - utils/add_ssh_config
-            - utils/make_status_shield:
-                  status: running
-                  color: lightblue
-                  file: ~/status.svg
-                  label: <<parameters.badge_label>>
-            - utils/rsync_file:
-                  file: ~/status.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-                  host: docs
-            - steps: <<parameters.setup>>
-            - setup_pipenv:
-                  pipenv_python_arg: <<parameters.pipenv_python_arg>>
-                  pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
-            - setup_badass_config:
-                  wd: <<parameters.wd>>
-            - steps: <<parameters.config>>
-            - run_tests:
-                  wd: <<parameters.wd>>
-                  parallel: <<parameters.parallel>>
-                  test_script: <<parameters.test_script>>
-            - coverage_combine_and_html:
-                  wd: <<parameters.wd>>
-            - store_test_results:
-                  path: test-results
-            - store_artifacts:
-                  path: test-results
-                  destination: tr1
-            - utils/rsync_folder:
-                  when: always
-                  folder: <<parameters.wd>>/htmlcov/
-                  remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
-                  host: docs
-            - utils/make_coverage_shield:
-                  when: always
-                  link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
-            - utils/rsync_file:
-                  when: always
-                  file: /tmp/coverage.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
-                  host: docs
-            - utils/make_status_shield:
-                  when: on_success
-                  status: passed
-                  color: brightgreen
-                  file: ~/status.svg
-                  label: <<parameters.badge_label>>
-            - utils/make_status_shield:
-                  when: on_fail
-                  status: failed
-                  color: red
-                  file: ~/status.svg
-                  label: <<parameters.badge_label>>
-            - utils/rsync_file:
-                  when: always
-                  file: ~/status.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-                  host: docs
+        steps: *common_badass_steps
     badass_test_pre_spread:
         parameters:
-            wd:
-                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
-                type: string
-                default: ${CIRCLE_PROJECT_REPONAME}
-            setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
-                type: steps
-                default: []
-            config:
-                description: "Any additional BMS configuration steps."
-                type: steps
-                default: []
-            executor:
-                description: "Execution environment for the test job."
-                type: executor
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-            badge_label:
-                description: "The label to use for the badge."
-                type: string
-                default: tests
-            meta_job_name:
-                description: "The filename to use for the badge."
-                type: string
-            pipenv_python_arg:
-                description: "Location or version of the python interpreter to use for pipenv."
-                type: string
-                default: ""
-            pipenv_skip_lock:
-                description: "Skip use of the pipenv lock file."
-                type: boolean
-                default: false
-            pipenv_cache_key_version:
-                description: "a string that can be changed to bust the pipenv cache."
-                type: string
-                default: "1"
+            <<: *common_badass_pre_spread_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        steps: *common_badass_pre_spread_steps
+    badass_test_pre_spread_fixed_ip:
+        parameters:
+            <<: *common_badass_pre_spread_parameters
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
-        steps:
-            - checkout
-            - utils/add_ssh_config
-            - utils/make_status_shield:
-                  status: running
-                  color: lightblue
-                  file: ~/status.svg
-                  label: <<parameters.badge_label>>
-            - utils/rsync_file:
-                  file: ~/status.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-                  host: docs
-            - steps: <<parameters.setup>>
-            - restore_cache:
-                  keys:
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-main
-            - setup_pipenv:
-                  pipenv_python_arg: <<parameters.pipenv_python_arg>>
-                  pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
-            - save_cache:
-                  paths:
-                      - ~/.local/share/virtualenvs
-                  key: pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-            - steps: <<parameters.config>>
-            - persist_to_workspace:
-                  root: ~/
-                  paths:
-                      - .local/share/virtualenvs
+        steps: *common_badass_pre_spread_steps
     badass_test_spread:
         parameters:
+            <<: *common_parameters
             repodir:
                 description: "Location of the git repo (no trailing slash)."
                 type: string
                 default: ~/project
-            wd:
-                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
-                type: string
-                default: ${CIRCLE_PROJECT_REPONAME}
-            executor:
-                description: "Execution environment for the test job."
-                type: executor
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
             parallel:
                 description: "The level of test parallelism."
                 type: integer
@@ -217,10 +260,6 @@ jobs:
                 description: "The level of test parallelism via circleci splitting."
                 type: integer
                 default: 4
-            setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
-                type: steps
-                default: []
             config:
                 description: "Any additional BMS configuration steps."
                 type: steps
@@ -268,14 +307,11 @@ jobs:
                       - workspace
     badass_test_combine:
         parameters:
+            <<: *common_parameters
             repodir:
                 description: "Location of the git repo (no trailing slash)."
                 type: string
                 default: ~/project
-            wd:
-                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
-                type: string
-                default: ${CIRCLE_PROJECT_REPONAME}
             badge_label:
                 description: "The label to use for the badge."
                 type: string
@@ -283,64 +319,30 @@ jobs:
             meta_job_name:
                 description: "The filename to use for the badge."
                 type: string
-            executor:
-                description: "Execution environment for the test job."
-                type: executor
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-            setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
-                type: steps
-                default: []
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        working_directory: <<parameters.repodir>>
+        steps: *common_badass_test_combine
+    badass_test_combine_fixed_ip:
+        parameters:
+            <<: *common_parameters
+            repodir:
+                description: "Location of the git repo (no trailing slash)."
+                type: string
+                default: ~/project
+            badge_label:
+                description: "The label to use for the badge."
+                type: string
+                default: tests
+            meta_job_name:
+                description: "The filename to use for the badge."
+                type: string
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
         working_directory: <<parameters.repodir>>
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - utils/add_ssh_config
-            - attach_workspace:
-                  at: ~/
-            - run:
-                  name: Restore workspace files
-                  command: |
-                      shopt -s dotglob
-                      cp ~/workspace/* <<parameters.wd>>/
-            - run:
-                  name: Combine status
-                  command: |
-                      if [ $(cat <<parameters.wd>>/0.status) -eq "0" ]; then
-                          diff -q --from-file <<parameters.wd>>/*.status && touch /tmp/passed
-                      fi
-            - utils/make_status_shield:
-                  status: $([ -f /tmp/passed ] && echo "passed" || echo "failed")
-                  color: $([ -f /tmp/passed ] && echo "brightgreen" || echo "red")
-                  file: /tmp/status.svg
-                  label: <<parameters.badge_label>>
-            - utils/rsync_file:
-                  when: always
-                  file: /tmp/status.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-                  host: docs
-            - coverage_combine_and_html:
-                  wd: <<parameters.wd>>
-            - utils/rsync_folder:
-                  when: always
-                  folder: <<parameters.wd>>/htmlcov/
-                  remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
-                  host: docs
-            - utils/make_coverage_shield:
-                  when: always
-                  file: /tmp/coverage.svg
-                  link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
-            - utils/rsync_file:
-                  when: always
-                  file: /tmp/coverage.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
-                  host: docs
+        steps: *common_badass_test_combine
 commands:
     setup_pipenv:
         description: "Setup pipenv."

--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,253 +1,210 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.13.0
-aliases:
-    common_parameters: &common_parameters
-        wd:
-            description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
-            type: string
-            default: ${CIRCLE_PROJECT_REPONAME}
-        setup:
-            description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
-            type: steps
-            default: []
-        executor:
-            description: "Execution environment for the test job."
-            type: executor
-        resource_class:
-            description: "The resource class to use for the job."
-            type: enum
-            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-    common_badass_parameters: &common_badass_parameters
-        <<: *common_parameters
-        repodir:
-            description: "Location of the git repo (no trailing slash)."
-            type: string
-            default: ~/project
-        config:
-            description: "Any additional BMS configuration steps."
-            type: steps
-            default: []
-        parallel:
-            description: "The level of test parallelism."
-            type: integer
-            default: 4
-        badge_label:
-            description: "The label to use for the badge."
-            type: string
-            default: tests
-        meta_job_name:
-            description: "The filename to use for the badge."
-            type: string
-        test_script:
-            description: "The test script to run (e.g., manage.py test)."
-            type: string
-            default: manage.py test
-        pipenv_python_arg:
-            description: "Location or version of the python interpreter to use for pipenv."
-            type: string
-            default: ""
-        pipenv_skip_lock:
-            description: "Skip use of the pipenv lock file."
-            type: boolean
-            default: false
-    common_badass_steps: &common_badass_steps
-        - checkout
-        - utils/add_maxmind_config
-        - utils/add_ssh_config
-        - utils/make_status_shield:
-              status: running
-              color: lightblue
-              file: ~/status.svg
-              label: <<parameters.badge_label>>
-        - utils/rsync_file:
-              file: ~/status.svg
-              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-              host: docs
-        - steps: <<parameters.setup>>
-        - setup_pipenv:
-              pipenv_python_arg: <<parameters.pipenv_python_arg>>
-              pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
-        - setup_badass_config:
-              wd: <<parameters.wd>>
-        - steps: <<parameters.config>>
-        - run_tests:
-              wd: <<parameters.wd>>
-              parallel: <<parameters.parallel>>
-              test_script: <<parameters.test_script>>
-        - coverage_combine_and_html:
-              wd: <<parameters.wd>>
-        - store_test_results:
-              path: test-results
-        - store_artifacts:
-              path: test-results
-              destination: tr1
-        - utils/rsync_folder:
-              when: always
-              folder: <<parameters.wd>>/htmlcov/
-              remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
-              host: docs
-        - utils/make_coverage_shield:
-              when: always
-              link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
-        - utils/rsync_file:
-              when: always
-              file: /tmp/coverage.svg
-              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
-              host: docs
-        - utils/make_status_shield:
-              when: on_success
-              status: passed
-              color: brightgreen
-              file: ~/status.svg
-              label: <<parameters.badge_label>>
-        - utils/make_status_shield:
-              when: on_fail
-              status: failed
-              color: red
-              file: ~/status.svg
-              label: <<parameters.badge_label>>
-        - utils/rsync_file:
-              when: always
-              file: ~/status.svg
-              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-              host: docs
-    common_badass_pre_spread_parameters: &common_badass_pre_spread_parameters
-        <<: *common_parameters
-        config:
-            description: "Any additional BMS configuration steps."
-            type: steps
-            default: []
-        badge_label:
-            description: "The label to use for the badge."
-            type: string
-            default: tests
-        meta_job_name:
-            description: "The filename to use for the badge."
-            type: string
-        pipenv_python_arg:
-            description: "Location or version of the python interpreter to use for pipenv."
-            type: string
-            default: ""
-        pipenv_skip_lock:
-            description: "Skip use of the pipenv lock file."
-            type: boolean
-            default: false
-        pipenv_cache_key_version:
-            description: "a string that can be changed to bust the pipenv cache."
-            type: string
-            default: "1"
-    common_badass_pre_spread_steps: &common_badass_pre_spread_steps
-        - checkout
-        - utils/add_ssh_config
-        - utils/make_status_shield:
-              status: running
-              color: lightblue
-              file: ~/status.svg
-              label: <<parameters.badge_label>>
-        - utils/rsync_file:
-              file: ~/status.svg
-              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-              host: docs
-        - steps: <<parameters.setup>>
-        - restore_cache:
-              keys:
-                  - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-                  - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
-                  - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-main
-        - setup_pipenv:
-              pipenv_python_arg: <<parameters.pipenv_python_arg>>
-              pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
-        - save_cache:
-              paths:
-                  - ~/.local/share/virtualenvs
-              key: pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-        - steps: <<parameters.config>>
-        - persist_to_workspace:
-              root: ~/
-              paths:
-                  - .local/share/virtualenvs
-    common_badass_test_combine: &common_badass_test_combine
-        - checkout
-        - steps: <<parameters.setup>>
-        - utils/add_ssh_config
-        - attach_workspace:
-              at: ~/
-        - run:
-              name: Restore workspace files
-              command: |
-                  shopt -s dotglob
-                  cp ~/workspace/* <<parameters.wd>>/
-        - run:
-              name: Combine status
-              command: |
-                  if [ $(cat <<parameters.wd>>/0.status) -eq "0" ]; then
-                      diff -q --from-file <<parameters.wd>>/*.status && touch /tmp/passed
-                  fi
-        - utils/make_status_shield:
-              status: $([ -f /tmp/passed ] && echo "passed" || echo "failed")
-              color: $([ -f /tmp/passed ] && echo "brightgreen" || echo "red")
-              file: /tmp/status.svg
-              label: <<parameters.badge_label>>
-        - utils/rsync_file:
-              when: always
-              file: /tmp/status.svg
-              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-              host: docs
-        - coverage_combine_and_html:
-              wd: <<parameters.wd>>
-        - utils/rsync_folder:
-              when: always
-              folder: <<parameters.wd>>/htmlcov/
-              remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
-              host: docs
-        - utils/make_coverage_shield:
-              when: always
-              file: /tmp/coverage.svg
-              link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
-        - utils/rsync_file:
-              when: always
-              file: /tmp/coverage.svg
-              remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
-              host: docs
+    utils: arrai/utils@1.11.0
 jobs:
     badass:
         parameters:
-            <<: *common_badass_parameters
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: false
-        working_directory: <<parameters.repodir>>
-        steps: *common_badass_steps
-    badass_fixed_ip:
-        parameters:
-            <<: *common_badass_parameters
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: true
-        working_directory: <<parameters.repodir>>
-        steps: *common_badass_steps
-    badass_test_pre_spread:
-        parameters:
-            <<: *common_badass_pre_spread_parameters
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: false
-        steps: *common_badass_pre_spread_steps
-    badass_test_pre_spread_fixed_ip:
-        parameters:
-            <<: *common_badass_pre_spread_parameters
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: true
-        steps: *common_badass_pre_spread_steps
-    badass_test_spread:
-        parameters:
-            <<: *common_parameters
             repodir:
                 description: "Location of the git repo (no trailing slash)."
                 type: string
                 default: ~/project
+            wd:
+                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
+                type: string
+                default: ${CIRCLE_PROJECT_REPONAME}
+            setup:
+                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+                type: steps
+                default: []
+            config:
+                description: "Any additional BMS configuration steps."
+                type: steps
+                default: []
+            executor:
+                description: "Execution environment for the test job."
+                type: executor
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            parallel:
+                description: "The level of test parallelism."
+                type: integer
+                default: 4
+            badge_label:
+                description: "The label to use for the badge."
+                type: string
+                default: tests
+            meta_job_name:
+                description: "The filename to use for the badge."
+                type: string
+            test_script:
+                description: "The test script to run (e.g., manage.py test)."
+                type: string
+                default: manage.py test
+            pipenv_python_arg:
+                description: "Location or version of the python interpreter to use for pipenv."
+                type: string
+                default: ""
+            pipenv_skip_lock:
+                description: "Skip use of the pipenv lock file."
+                type: boolean
+                default: false
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        working_directory: <<parameters.repodir>>
+        steps:
+            - checkout
+            - utils/add_maxmind_config
+            - utils/add_ssh_config
+            - utils/make_status_shield:
+                  status: running
+                  color: lightblue
+                  file: ~/status.svg
+                  label: <<parameters.badge_label>>
+            - utils/rsync_file:
+                  file: ~/status.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+                  host: docs
+            - steps: <<parameters.setup>>
+            - setup_pipenv:
+                  pipenv_python_arg: <<parameters.pipenv_python_arg>>
+                  pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
+            - setup_badass_config:
+                  wd: <<parameters.wd>>
+            - steps: <<parameters.config>>
+            - run_tests:
+                  wd: <<parameters.wd>>
+                  parallel: <<parameters.parallel>>
+                  test_script: <<parameters.test_script>>
+            - coverage_combine_and_html:
+                  wd: <<parameters.wd>>
+            - store_test_results:
+                  path: test-results
+            - store_artifacts:
+                  path: test-results
+                  destination: tr1
+            - utils/rsync_folder:
+                  when: always
+                  folder: <<parameters.wd>>/htmlcov/
+                  remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
+                  host: docs
+            - utils/make_coverage_shield:
+                  when: always
+                  link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
+            - utils/rsync_file:
+                  when: always
+                  file: /tmp/coverage.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
+                  host: docs
+            - utils/make_status_shield:
+                  when: on_success
+                  status: passed
+                  color: brightgreen
+                  file: ~/status.svg
+                  label: <<parameters.badge_label>>
+            - utils/make_status_shield:
+                  when: on_fail
+                  status: failed
+                  color: red
+                  file: ~/status.svg
+                  label: <<parameters.badge_label>>
+            - utils/rsync_file:
+                  when: always
+                  file: ~/status.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+                  host: docs
+    badass_test_pre_spread:
+        parameters:
+            wd:
+                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
+                type: string
+                default: ${CIRCLE_PROJECT_REPONAME}
+            setup:
+                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+                type: steps
+                default: []
+            config:
+                description: "Any additional BMS configuration steps."
+                type: steps
+                default: []
+            executor:
+                description: "Execution environment for the test job."
+                type: executor
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            badge_label:
+                description: "The label to use for the badge."
+                type: string
+                default: tests
+            meta_job_name:
+                description: "The filename to use for the badge."
+                type: string
+            pipenv_python_arg:
+                description: "Location or version of the python interpreter to use for pipenv."
+                type: string
+                default: ""
+            pipenv_skip_lock:
+                description: "Skip use of the pipenv lock file."
+                type: boolean
+                default: false
+            pipenv_cache_key_version:
+                description: "a string that can be changed to bust the pipenv cache."
+                type: string
+                default: "1"
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps:
+            - checkout
+            - utils/add_ssh_config
+            - utils/make_status_shield:
+                  status: running
+                  color: lightblue
+                  file: ~/status.svg
+                  label: <<parameters.badge_label>>
+            - utils/rsync_file:
+                  file: ~/status.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+                  host: docs
+            - steps: <<parameters.setup>>
+            - restore_cache:
+                  keys:
+                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
+                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-main
+            - setup_pipenv:
+                  pipenv_python_arg: <<parameters.pipenv_python_arg>>
+                  pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
+            - save_cache:
+                  paths:
+                      - ~/.local/share/virtualenvs
+                  key: pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+            - steps: <<parameters.config>>
+            - persist_to_workspace:
+                  root: ~/
+                  paths:
+                      - .local/share/virtualenvs
+    badass_test_spread:
+        parameters:
+            repodir:
+                description: "Location of the git repo (no trailing slash)."
+                type: string
+                default: ~/project
+            wd:
+                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
+                type: string
+                default: ${CIRCLE_PROJECT_REPONAME}
+            executor:
+                description: "Execution environment for the test job."
+                type: executor
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
             parallel:
                 description: "The level of test parallelism."
                 type: integer
@@ -260,6 +217,10 @@ jobs:
                 description: "The level of test parallelism via circleci splitting."
                 type: integer
                 default: 4
+            setup:
+                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+                type: steps
+                default: []
             config:
                 description: "Any additional BMS configuration steps."
                 type: steps
@@ -307,11 +268,14 @@ jobs:
                       - workspace
     badass_test_combine:
         parameters:
-            <<: *common_parameters
             repodir:
                 description: "Location of the git repo (no trailing slash)."
                 type: string
                 default: ~/project
+            wd:
+                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
+                type: string
+                default: ${CIRCLE_PROJECT_REPONAME}
             badge_label:
                 description: "The label to use for the badge."
                 type: string
@@ -319,30 +283,64 @@ jobs:
             meta_job_name:
                 description: "The filename to use for the badge."
                 type: string
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: false
-        working_directory: <<parameters.repodir>>
-        steps: *common_badass_test_combine
-    badass_test_combine_fixed_ip:
-        parameters:
-            <<: *common_parameters
-            repodir:
-                description: "Location of the git repo (no trailing slash)."
-                type: string
-                default: ~/project
-            badge_label:
-                description: "The label to use for the badge."
-                type: string
-                default: tests
-            meta_job_name:
-                description: "The filename to use for the badge."
-                type: string
+            executor:
+                description: "Execution environment for the test job."
+                type: executor
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            setup:
+                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+                type: steps
+                default: []
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
         working_directory: <<parameters.repodir>>
-        steps: *common_badass_test_combine
+        steps:
+            - checkout
+            - steps: <<parameters.setup>>
+            - utils/add_ssh_config
+            - attach_workspace:
+                  at: ~/
+            - run:
+                  name: Restore workspace files
+                  command: |
+                      shopt -s dotglob
+                      cp ~/workspace/* <<parameters.wd>>/
+            - run:
+                  name: Combine status
+                  command: |
+                      if [ $(cat <<parameters.wd>>/0.status) -eq "0" ]; then
+                          diff -q --from-file <<parameters.wd>>/*.status && touch /tmp/passed
+                      fi
+            - utils/make_status_shield:
+                  status: $([ -f /tmp/passed ] && echo "passed" || echo "failed")
+                  color: $([ -f /tmp/passed ] && echo "brightgreen" || echo "red")
+                  file: /tmp/status.svg
+                  label: <<parameters.badge_label>>
+            - utils/rsync_file:
+                  when: always
+                  file: /tmp/status.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+                  host: docs
+            - coverage_combine_and_html:
+                  wd: <<parameters.wd>>
+            - utils/rsync_folder:
+                  when: always
+                  folder: <<parameters.wd>>/htmlcov/
+                  remote_folder: ${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>
+                  host: docs
+            - utils/make_coverage_shield:
+                  when: always
+                  file: /tmp/coverage.svg
+                  link: https://${DOCS_HOST}/${CIRCLE_PROJECT_REPONAME}/artifacts/${CIRCLE_BRANCH}/htmlcov_<<parameters.meta_job_name>>/
+            - utils/rsync_file:
+                  when: always
+                  file: /tmp/coverage.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
+                  host: docs
 commands:
     setup_pipenv:
         description: "Setup pipenv."

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.10.0
+    utils: arrai/utils@1.13.0
 commands:
     upgrade_npm:
         steps:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -12,89 +12,100 @@ commands:
                       else
                           npm install -g --upgrade npm
                       fi
+aliases:
+    common_parameters: &common_parameters
+        wd:
+            description: "The working directory for this job."
+            type: string
+            default: ~/project
+        files:
+            description: "Files/Directories to lint."
+            type: string
+            default: lib/**
+        executor:
+            description: "The executor to use for the job."
+            type: executor
+            default: v18
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+        config:
+            description: "Any additional configuration steps."
+            type: steps
+            default: []
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+            default: true
+    common_steps: &common_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - upgrade_npm
+        - utils/add_npm_config
+        - steps: <<parameters.config>>
+        - run:
+              name: Run eslint
+              command: |
+                  cd <<parameters.wd>>
+                  npx -y eslint --color <<parameters.files>> | tee ~/lint
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - run:
+                        name: Install additional OS packages
+                        command: |
+                            sudo apt update
+                            sudo apt install rsync
+                  - utils/add_ssh_config
+                  - utils/make_status_shield:
+                        when: on_fail
+                        status: errors
+                        color: red
+                        logo: eslint
+        - run:
+              name: Check if we had any warnings
+              when: always
+              command: test ! -s ~/lint
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - utils/make_status_shield:
+                        when: always
+                        status: warnings
+                        color: orange
+                        logo: eslint
+                        preserve: true
+                  - utils/make_status_shield:
+                        when: on_success
+                        status: passed
+                        color: brightgreen
+                        logo: eslint
+                  - utils/rsync_file:
+                        when: always
+                        file: ~/status.svg
+                        remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
+                        host: doc
 jobs:
     eslint:
         parameters:
-            wd:
-                description: "The working directory for this job."
-                type: string
-                default: ~/project
-            files:
-                description: "Files/Directories to lint."
-                type: string
-                default: lib/**
-            executor:
-                description: "The executor to use for the job."
-                type: executor
-                default: v18
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
-            config:
-                description: "Any additional configuration steps."
-                type: steps
-                default: []
-            create_badges:
-                description: "Generate badges."
-                type: boolean
-                default: true
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        steps: *common_steps
+    eslint_fixed_ip:
+        parameters:
+            <<: *common_parameters
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - upgrade_npm
-            - utils/add_npm_config
-            - steps: <<parameters.config>>
-            - run:
-                  name: Run eslint
-                  command: |
-                      cd <<parameters.wd>>
-                      npx -y eslint --color <<parameters.files>> | tee ~/lint
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - run:
-                            name: Install additional OS packages
-                            command: |
-                                sudo apt update
-                                sudo apt install rsync
-                      - utils/add_ssh_config
-                      - utils/make_status_shield:
-                            when: on_fail
-                            status: errors
-                            color: red
-                            logo: eslint
-            - run:
-                  name: Check if we had any warnings
-                  when: always
-                  command: test ! -s ~/lint
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - utils/make_status_shield:
-                            when: always
-                            status: warnings
-                            color: orange
-                            logo: eslint
-                            preserve: true
-                      - utils/make_status_shield:
-                            when: on_success
-                            status: passed
-                            color: brightgreen
-                            logo: eslint
-                      - utils/rsync_file:
-                            when: always
-                            file: ~/status.svg
-                            remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
-                            host: docs
+        steps: *common_steps
 executors:
     lts:
         environment:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -117,26 +117,6 @@ executors:
             LANG: en_US.UTF-8
         docker:
             - image: cimg/node:current
-    v10:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:10.24
-    v12:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:12.22
-    v14:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:14.21.3
-    v16:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:16.20.2
     v18:
         environment:
             LANG: en_US.UTF-8

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -121,9 +121,9 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.17.1
+            - image: cimg/node:18.18
     v20:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:20.5.1
+            - image: cimg/node:20.9

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -40,6 +40,7 @@ aliases:
         create_badges:
             description: "Generate badges."
             type: boolean
+            default: true
     common_badge_upload: &common_badge_upload
         - utils/add_ssh_config
         - run:

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -14,105 +14,129 @@ executors:
     python36:
         docker:
             - image: cimg/python:3.6
+aliases:
+    common_parameters: &common_parameters
+        flake8_cmd:
+            description: "The flake8 command to use; allows for alternatives (e.g. pflake)."
+            type: string
+            default: "flake8"
+        wd:
+            description: "The working directory for the job."
+            type: string
+            default: ./${CIRCLE_PROJECT_REPONAME}
+        executor:
+            description: "The executor to use for the job."
+            type: executor
+            default: python38
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+    common_badge_upload: &common_badge_upload
+        - utils/add_ssh_config
+        - run:
+              name: Install additional OS packages
+              command: |
+                  if [ -f /usr/bin/apt ]; then
+                      sudo apt update
+                      sudo apt install rsync
+                  elif [ -f /usr/bin/yum ]; then
+                      sudo yum -y install rsync
+                  fi
+        - utils/make_status_shield:
+              when: on_fail
+              status: errors
+              color: red
+              logo: python
+        - utils/make_status_shield:
+              when: on_success
+              status: passed
+              color: brightgreen
+              logo: python
+        - utils/rsync_file:
+              when: always
+              file: ~/status.svg
+              remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
+              host: docs
+    common_flake8_steps: &common_flake8_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - setup_flake8:
+              wd: <<parameters.wd>>
+              additional_packages: <<parameters.additional_packages>>
+        - flake8_errors:
+              flake8_cmd: <<parameters.flake8_cmd>>
+              wd: <<parameters.wd>>
+        - when:
+              condition: <<parameters.create_badges>>
+              steps: *common_badge_upload
+    common_flake8_pipenv_steps: &common_flake8_pipenv_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - setup_flake8_pipenv:
+              wd: <<parameters.wd>>
+              pipenv_meta_job_name: <<parameters.pipenv_meta_job_name>>
+              pipenv_cache_key_version: <<parameters.pipenv_cache_key_version>>
+        - flake8_errors_pipenv:
+              flake8_cmd: <<parameters.flake8_cmd>>
+              wd: <<parameters.wd>>
+        - when:
+              condition: <<parameters.create_badges>>
+              steps: *common_badge_upload
 jobs:
     flake8:
         parameters:
-            flake8_cmd:
-                description: "The flake8 command to use; allows for alternatives (e.g. pflake)."
-                type: string
-                default: "flake8"
-            wd:
-                description: "The working directory for the job."
-                type: string
-                default: ./${CIRCLE_PROJECT_REPONAME}
-            executor:
-                description: "The executor to use for the job."
-                type: executor
-                default: python38
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
+            <<: *common_parameters
             additional_packages:
                 description: "Allows installing additional packages or requirements.txt files."
                 type: string
                 default: ""
-            create_badges:
-                description: "Generate badges."
-                type: boolean
-                default: true
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: true
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - setup_flake8:
-                  wd: <<parameters.wd>>
-                  additional_packages: <<parameters.additional_packages>>
-            - flake8_errors:
-                  flake8_cmd: <<parameters.flake8_cmd>>
-                  wd: <<parameters.wd>>
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - utils/add_ssh_config
-                      - run:
-                            name: Install additional OS packages
-                            command: |
-                                if [ -f /usr/bin/apt ]; then
-                                    sudo apt update
-                                    sudo apt install rsync
-                                elif [ -f /usr/bin/yum ]; then
-                                    sudo yum -y install rsync
-                                fi
-                      - utils/make_status_shield:
-                            when: on_fail
-                            status: errors
-                            color: red
-                            logo: python
-                      - utils/make_status_shield:
-                            when: on_success
-                            status: passed
-                            color: brightgreen
-                            logo: python
-                      - utils/rsync_file:
-                            when: always
-                            file: ~/status.svg
-                            remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
-                            host: docs
-    flake8_pipenv:
+        circleci_ip_ranges: false
+        steps: *common_flake8_steps
+    flake8_fixed_ip:
         parameters:
+            <<: *common_parameters
             flake8_cmd:
                 description: "The flake8 command to use; allows for alternatives (e.g. pflake)."
                 type: string
                 default: "flake8"
-            wd:
-                description: "The working directory for the job."
+            additional_packages:
+                description: "Allows installing additional packages or requirements.txt files."
                 type: string
-                default: .
-            executor:
-                description: "The executor to use for the job."
-                type: executor
-                default: python38
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
-            create_badges:
-                description: "Generate badges."
-                type: boolean
-                default: true
+                default: ""
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps: *common_flake8_steps
+    flake8_pipenv:
+        parameters:
+            <<: *common_parameters
+            pipenv_meta_job_name:
+                description: "a test job's meta job name for sharing pipenv cache."
+                type: string
+            pipenv_cache_key_version:
+                description: "a string that can be changed to bust the pipenv cache."
+                type: string
+                default: "1"
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        environment:
+            PIPENV_DONT_LOAD_ENV: 1
+        steps: *common_flake8_pipenv_steps
+    flake8_pipenv_fixed_ip:
+        parameters:
+            <<: *common_parameters
             pipenv_meta_job_name:
                 description: "a test job's meta job name for sharing pipenv cache."
                 type: string
@@ -125,44 +149,7 @@ jobs:
         circleci_ip_ranges: true
         environment:
             PIPENV_DONT_LOAD_ENV: 1
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - setup_flake8_pipenv:
-                  wd: <<parameters.wd>>
-                  pipenv_meta_job_name: <<parameters.pipenv_meta_job_name>>
-                  pipenv_cache_key_version: <<parameters.pipenv_cache_key_version>>
-            - flake8_errors_pipenv:
-                  flake8_cmd: <<parameters.flake8_cmd>>
-                  wd: <<parameters.wd>>
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - utils/add_ssh_config
-                      - run:
-                            name: Install additional OS packages
-                            command: |
-                                if [ -f /usr/bin/apt ]; then
-                                    sudo apt update
-                                    sudo apt install rsync
-                                elif [ -f /usr/bin/yum ]; then
-                                    sudo yum -y install rsync
-                                fi
-                      - utils/make_status_shield:
-                            when: on_fail
-                            status: errors
-                            color: red
-                            logo: python
-                      - utils/make_status_shield:
-                            when: on_success
-                            status: passed
-                            color: brightgreen
-                            logo: python
-                      - utils/rsync_file:
-                            when: always
-                            file: ~/status.svg
-                            remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
-                            host: docs
+        steps: *common_flake8_pipenv_steps
 commands:
     setup_flake8:
         description: "Set up a python virtual environment to run flake8"

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.10.0
+    utils: arrai/utils@1.13.0
 executors:
     python310:
         docker:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -22,6 +22,97 @@ executors:
             LANG: en_US.UTF-8
         docker:
             - image: cimg/node:20.9
+aliases:
+    common_audit_parameters: &common_audit_parameters
+        wd:
+            type: string
+            default: ~/project
+        executor:
+            type: executor
+            default: lts
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default:
+                - run:
+                      name: "Install additional OS packages"
+                      command: |
+                          sudo apt update
+                          sudo apt install rsync colorized-logs jq
+        config:
+            description: "Any additional configuration steps."
+            type: steps
+            default: []
+        report_to:
+            description: "E-mail address to send npm audit failure report to."
+            type: string
+            default: ""
+        skip_dev:
+            description: "Don't check development dependencies."
+            type: boolean
+            default: true
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+            default: true
+    common_audit_steps: &common_audit_steps
+        - checkout
+        - utils/add_ssh_config
+        - steps: <<parameters.setup>>
+        - upgrade_npm
+        - utils/add_npm_config
+        - steps: <<parameters.config>>
+        - run:
+              name: "Run npm audit"
+              command: |
+                  cd <<parameters.wd>>
+                  npx -y better-npm-audit audit <<# parameters.skip_dev >> -p <</ parameters.skip_dev >> |& tee ~/audit.log
+        - run:
+              name: "Generate HTML audit report"
+              when: on_fail
+              command: cat ${HOME}/audit.log | ansi2html > ${HOME}/audit.html
+        - when:
+              condition: <<parameters.report_to>>
+              steps:
+                  - utils/send_email:
+                        when: on_fail
+                        to: <<parameters.report_to>>
+                        subject: "npm audit report for ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
+                        html: "<${HOME}/audit.html"
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - run:
+                        name: "Count vulnerabilities"
+                        when: on_fail
+                        command: |
+                            if [ -f ~/audit.log ]; then
+                                echo "export TOTAL_VULNERABILITIES=`tail -1 ~/audit.log | grep -Po '^(\d+)' --color=never`" >> $BASH_ENV
+                            else
+                                echo "export TOTAL_VULNERABILITIES=?" >> $BASH_ENV
+                             fi
+                  - utils/make_status_shield:
+                        when: on_fail
+                        status: "${TOTAL_VULNERABILITIES}"
+                        label: vulnerabilities
+                        color: red
+                        logo: npm
+                  - utils/make_status_shield:
+                        when: on_success
+                        status: "0"
+                        label: vulnerabilities
+                        color: brightgreen
+                        logo: npm
+                  - utils/rsync_file:
+                        when: always
+                        file: ~/status.svg
+                        remote_file: ${CIRCLE_BRANCH}/npm-audit.svg
+                        host: docs
 commands:
     upgrade_npm:
         steps:
@@ -36,98 +127,19 @@ commands:
 jobs:
     audit:
         parameters:
-            wd:
-                type: string
-                default: ~/project
-            executor:
-                type: executor
-                default: lts
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default:
-                    - run:
-                          name: "Install additional OS packages"
-                          command: |
-                              sudo apt update
-                              sudo apt install rsync colorized-logs jq
-            config:
-                description: "Any additional configuration steps."
-                type: steps
-                default: []
-            report_to:
-                description: "E-mail address to send npm audit failure report to."
-                type: string
-                default: ""
-            skip_dev:
-                description: "Don't check development dependencies."
-                type: boolean
-                default: true
-            create_badges:
-                description: "Generate badges."
-                type: boolean
-                default: true
+            <<: *common_audit_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        steps: *common_audit_steps
+
+    audit_fixed_ip:
+        parameters:
+            <<: *common_audit_parameters
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
-        steps:
-            - checkout
-            - utils/add_ssh_config
-            - steps: <<parameters.setup>>
-            - upgrade_npm
-            - utils/add_npm_config
-            - steps: <<parameters.config>>
-            - run:
-                  name: "Run npm audit"
-                  command: |
-                      cd <<parameters.wd>>
-                      npx -y better-npm-audit audit <<# parameters.skip_dev >> -p <</ parameters.skip_dev >> |& tee ~/audit.log
-            - run:
-                  name: "Generate HTML audit report"
-                  when: on_fail
-                  command: cat ${HOME}/audit.log | ansi2html > ${HOME}/audit.html
-            - when:
-                  condition: <<parameters.report_to>>
-                  steps:
-                      - utils/send_email:
-                            when: on_fail
-                            to: <<parameters.report_to>>
-                            subject: "npm audit report for ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}"
-                            html: "<${HOME}/audit.html"
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - run:
-                            name: "Count vulnerabilities"
-                            when: on_fail
-                            command: |
-                                if [ -f ~/audit.log ]; then
-                                    echo "export TOTAL_VULNERABILITIES=`tail -1 ~/audit.log | grep -Po '^(\d+)' --color=never`" >> $BASH_ENV
-                                else
-                                    echo "export TOTAL_VULNERABILITIES=?" >> $BASH_ENV
-                                fi
-                      - utils/make_status_shield:
-                            when: on_fail
-                            status: "${TOTAL_VULNERABILITIES}"
-                            label: vulnerabilities
-                            color: red
-                            logo: npm
-                      - utils/make_status_shield:
-                            when: on_success
-                            status: "0"
-                            label: vulnerabilities
-                            color: brightgreen
-                            logo: npm
-                      - utils/rsync_file:
-                            when: always
-                            file: ~/status.svg
-                            remote_file: ${CIRCLE_BRANCH}/npm-audit.svg
-                            host: docs
+        steps: *common_audit_steps
     coverage:
         parameters:
             wd:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.10.0
+    utils: arrai/utils@1.13.0
 executors:
     lts:
         environment:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -12,21 +12,6 @@ executors:
             LANG: en_US.UTF-8
         docker:
             - image: cimg/node:current
-    v12:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:12.22
-    v14:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:14.21.3
-    v16:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:16.20.2
     v18:
         environment:
             LANG: en_US.UTF-8

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -16,12 +16,12 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.17.1
+            - image: cimg/node:18.18
     v20:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:20.5.1
+            - image: cimg/node:20.9
 commands:
     upgrade_npm:
         steps:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.12.0
+    utils: arrai/utils@1.13.0
 executors:
     node18:
         environment:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -6,7 +6,7 @@ executors:
         environment:
             LANG: C.UTF-8
         docker:
-            - image: cimg/node:18.17.1-browsers
+            - image: cimg/node:18.18-browsers
 aliases:
     common_parameters: &common_parameters
         wd:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -7,87 +7,98 @@ executors:
             LANG: C.UTF-8
         docker:
             - image: cimg/node:18.17.1-browsers
-jobs:
-    code_style:
-        parameters:
-            wd:
-                description: "The working directory for the job."
-                type: string
-                default: ~/project
-            executor:
-                description: "The executor to use for the job."
-                type: executor
-                default: node18
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            version:
-                description: "The version of prettier to use."
-                type: string
-                default: ""
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
-            config:
-                description: "Any additional configuration steps."
-                type: steps
-                default: []
-            create_badges:
-                description: "Generate badges."
-                type: boolean
-                default: true
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: true
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - utils/add_npm_config
-            - steps: <<parameters.config>>
-            - run:
-                  name: Install prettier
-                  command: |
-                      cd <<parameters.wd>>
-                      if [ "$(which npm)" = "/usr/local/bin/npm" ]; then
-                          if [ ! -z <<parameters.version>> ]; then
-                              sudo npm install -g prettier@<<parameters.version>>
-                          else
-                              npm ci
-                          fi
-                      elif [ ! -z <<parameters.version>> ]; then
-                          npm install -g prettier@<<parameters.version>>
+aliases:
+    common_parameters: &common_parameters
+        wd:
+            description: "The working directory for the job."
+            type: string
+            default: ~/project
+        executor:
+            description: "The executor to use for the job."
+            type: executor
+            default: node18
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        version:
+            description: "The version of prettier to use."
+            type: string
+            default: ""
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+        config:
+            description: "Any additional configuration steps."
+            type: steps
+            default: []
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+            default: true
+    common_steps: &common_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - utils/add_npm_config
+        - steps: <<parameters.config>>
+        - run:
+              name: Install prettier
+              command: |
+                  cd <<parameters.wd>>
+                  if [ "$(which npm)" = "/usr/local/bin/npm" ]; then
+                      if [ ! -z <<parameters.version>> ]; then
+                          sudo npm install -g prettier@<<parameters.version>>
                       else
                           npm ci
                       fi
-            - run:
-                  name: Check prettier
-                  command: |
-                      cd <<parameters.wd>>
-                      npx prettier -c .
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - utils/add_ssh_config
-                      - run:
-                            name: Install additional OS packages
-                            command: |
-                                sudo apt update
-                                sudo apt install rsync
-                      - utils/make_status_shield:
-                            when: on_fail
-                            status: not_quite_prettier
-                            color: red
-                            logo: prettier
-                      - utils/make_status_shield:
-                            when: on_success
-                            status: prettier
-                            color: ff69b4
-                            logo: prettier
-                      - utils/rsync_file:
-                            when: always
-                            file: ~/status.svg
-                            remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
-                            host: docs
+                  elif [ ! -z <<parameters.version>> ]; then
+                      npm install -g prettier@<<parameters.version>>
+                  else
+                      npm ci
+                  fi
+        - run:
+              name: Check prettier
+              command: |
+                  cd <<parameters.wd>>
+                  npx prettier -c .
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - utils/add_ssh_config
+                  - run:
+                        name: Install additional OS packages
+                        command: |
+                            sudo apt update
+                            sudo apt install rsync
+                  - utils/make_status_shield:
+                        when: on_fail
+                        status: not_quite_prettier
+                        color: red
+                        logo: prettier
+                  - utils/make_status_shield:
+                        when: on_success
+                        status: prettier
+                        color: ff69b4
+                        logo: prettier
+                  - utils/rsync_file:
+                        when: always
+                        file: ~/status.svg
+                        remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
+                        host: docs
+jobs:
+    code_style:
+        parameters:
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        steps: *common_steps
+    code_style_fixed_ip:
+        parameters:
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps: *common_steps

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -56,6 +56,7 @@ jobs:
                 default: "1"
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
         environment:
             PIPENV_DONT_LOAD_ENV: 1
         steps:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -3,7 +3,7 @@ description: |
     This job requires `pytest-cov` and `coverage` to be installed as `pipenv` `devDependences`.
     Configure pytest and coverage via pyproject.toml.
 orbs:
-    utils: arrai/utils@1.12.0
+    utils: arrai/utils@1.13.0
 executors:
     python310:
         docker:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.10.0
+    utils: arrai/utils@1.13.0
 executors:
     python310:
         docker:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -14,90 +14,103 @@ executors:
     python36:
         docker:
             - image: cimg/python:3.6
+aliases:
+    common_parameters: &common_parameters
+        executor:
+            description: "The executor to use for the job."
+            type: executor
+            default: python310
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        config:
+            description: "Any additional configuration steps."
+            type: steps
+            default: []
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+            default: true
+        ignored_vulnerabilities:
+            description: "List of ignored vulnerabilities, e.g. '-i 123 -i 456'"
+            type: string
+            default: ""
+        pipenv_cache_key_version:
+            description: "a string that can be changed to bust the pipenv cache."
+            type: string
+            default: "1"
+    common_steps: &common_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - run:
+              name: Keep track of the python version.
+              command: |
+                  python --version > /tmp/python.version
+        - restore_cache: # ensure this step occurs *before* installing dependencies
+              keys:
+                  - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+                  - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
+                  - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-main
+        - run:
+              name: Set up python environment
+              command: |
+                  pip list --outdated --format=json | jq -r '.[]|.name' | xargs -r pip install -U
+                  pipenv sync | cat; test ${PIPESTATUS[0]} -eq 0
+        - save_cache:
+              paths:
+                  - ~/.local/share/virtualenvs/
+              key: pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+        - steps: <<parameters.config>>
+        - run:
+              name: Run safety
+              command: |
+                  pipenv check <<parameters.ignored_vulnerabilities>>
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - utils/add_ssh_config
+                  - run:
+                        name: Install additional OS packages
+                        command: |
+                            sudo apt update
+                            sudo apt install rsync
+                  - utils/make_status_shield:
+                        when: on_fail
+                        status: errors
+                        color: red
+                        logo: python
+                  - utils/make_status_shield:
+                        when: on_success
+                        status: passed
+                        color: brightgreen
+                        logo: python
+                  - utils/rsync_file:
+                        when: always
+                        file: ~/status.svg
+                        remote_file: ${CIRCLE_BRANCH}/${CIRCLE_JOB}.svg
+                        host: docs
 jobs:
     safety:
         parameters:
-            executor:
-                description: "The executor to use for the job."
-                type: executor
-                default: python310
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            config:
-                description: "Any additional configuration steps."
-                type: steps
-                default: []
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
-            create_badges:
-                description: "Generate badges."
-                type: boolean
-                default: true
-            ignored_vulnerabilities:
-                description: "List of ignored vulnerabilities, e.g. '-i 123 -i 456'"
-                type: string
-                default: ""
-            pipenv_cache_key_version:
-                description: "a string that can be changed to bust the pipenv cache."
-                type: string
-                default: "1"
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        environment:
+            PIPENV_DONT_LOAD_ENV: 1
+        steps: *common_steps
+    safety_fixed_ip:
+        parameters:
+            <<: *common_parameters
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
         environment:
             PIPENV_DONT_LOAD_ENV: 1
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - run:
-                  name: Keep track of the python version.
-                  command: |
-                      python --version > /tmp/python.version
-            - restore_cache: # ensure this step occurs *before* installing dependencies
-                  keys:
-                      - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-main
-            - run:
-                  name: Set up python environment
-                  command: |
-                      pip list --outdated --format=json | jq -r '.[]|.name' | xargs -r pip install -U
-                      pipenv sync | cat; test ${PIPESTATUS[0]} -eq 0
-            - save_cache:
-                  paths:
-                      - ~/.local/share/virtualenvs/
-                  key: pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-            - steps: <<parameters.config>>
-            - run:
-                  name: Run safety
-                  command: |
-                      pipenv check <<parameters.ignored_vulnerabilities>>
-            - when:
-                  condition: <<parameters.create_badges>>
-                  steps:
-                      - utils/add_ssh_config
-                      - run:
-                            name: Install additional OS packages
-                            command: |
-                                sudo apt update
-                                sudo apt install rsync
-                      - utils/make_status_shield:
-                            when: on_fail
-                            status: errors
-                            color: red
-                            logo: python
-                      - utils/make_status_shield:
-                            when: on_success
-                            status: passed
-                            color: brightgreen
-                            logo: python
-                      - utils/rsync_file:
-                            when: always
-                            file: ~/status.svg
-                            remote_file: ${CIRCLE_BRANCH}/${CIRCLE_JOB}.svg
-                            host: docs
+        steps: *common_steps


### PR DESCRIPTION
As mentioned in the [discussion here](https://discuss.circleci.com/t/ip-ranges-open-preview/40864), using `circleci_ip_ranges` in a configurable way by passing in the value via an exposed parameter is currently broken. Since this has been an open issue for a long time, I'm not holding my breath that this will get fixed any time soon.

The workaround is rather annoying; create separately named jobs that can be called as appropriate. In order for this not to lead to massive amounts of code duplication, I'm reusing the parameters and steps in those jobs via aliases & anchors.

This means many jobs now have been duplicated with a `fixed_ip` suffix to indicate those run in the fixed network range.

`arrai/eslint@7.8.0`
- `eslint`
- `eslint_fixed_ip`

`arrai/prettier@5.7.0`
- `code_style`
- `code_style_fixed_ip`

`arrai/npm@2.11.0`
- `audit`
- `audit_fixed_ip`

`arrai/flake8@18.0.0`
- `flake8`
- `flake8_fixed_ip`
- `flake8_pipenv`
- `flake8_pipenv_fixed_ip`

These two always upload files, so they've been set up to always used fixed ip ranges.
`arrai/pytest@7.2.0`
`arrai/safety@2.2.0`

