### PR TITLE
feat: allow venv-based tests again

### DIFF
--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,34 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.11.0
+    utils: arrai/utils@1.13.0
+aliases:
+    pre_spread_common_parameters: &pre_spread_common_parameters
+        wd:
+            description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
+            type: string
+            default: ${CIRCLE_PROJECT_REPONAME}
+        setup:
+            description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+            type: steps
+            default: []
+        config:
+            description: "Any additional BMS configuration steps."
+            type: steps
+            default: []
+        executor:
+            description: "Execution environment for the test job."
+            type: executor
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+        badge_label:
+            description: "The label to use for the badge."
+            type: string
+            default: tests
+        meta_job_name:
+            description: "The filename to use for the badge."
+            type: string
 jobs:
     badass:
         parameters:
@@ -115,34 +143,72 @@ jobs:
                   file: ~/status.svg
                   remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
                   host: docs
+    badass_venv_test_pre_spread:
+        parameters:
+            <<: *pre_spread_common_parameters
+            dash_r_files:
+                description: "space seperated paths to requirements files."
+                type: string
+                default: "${CIRCLE_PROJECT_REPONAME}/requirements.txt ${CIRCLE_PROJECT_REPONAME}/test_requirements.txt"
+            extra_pip_args:
+                description: "Any additional arguments to pip install."
+                type: string
+                default: ""
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps:
+            - checkout
+            - utils/add_ssh_config
+            - utils/make_status_shield:
+                  status: running
+                  color: lightblue
+                  file: ~/status.svg
+                  label: <<parameters.badge_label>>
+            - utils/rsync_file:
+                  file: ~/status.svg
+                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
+                  host: docs
+            - steps: <<parameters.setup>>
+            - run:
+                  name: "Create cache checksum."
+                  command: |
+                      cd <<parameters.wd>>
+                      sha256sum <<parameters.dash_r_files>> > /tmp/requirements-checksum
+            - restore_cache:
+                  keys:
+                      - pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-{{ .Branch }}-{{ checksum "/tmp/requirements-checksum" }}
+                      - pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-{{ .Branch }}
+                      - pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>
+            - run:
+                  name: "Setup Python virtual environment"
+                  command: |
+                      mkdir -p logs/${CIRCLE_PROJECT_REPONAME}
+                      cd <<parameters.wd>>
+                      DASH_R_FILES_ARRAY=(<<parameters.dash_r_files>>)
+                      DASH_R_FILES=${DASH_R_FILES_ARRAY[@]/#/-r }
+                      pip install $DASH_R_FILES <<parameters.extra_pip_args>> | cat; test ${PIPESTATUS[0]} -eq 0
+                      echo "import coverage; coverage.process_startup()" > `python -c "import sys; import os; print([x for x in sys.path if x.find(os.path.expanduser('~/.venv')) != -1 and x.find('site-packages') != -1][0] + '/coverage-all-the-things.pth')"`
+            - save_cache:
+                  paths:
+                      - ~/.venv
+                  key: pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-{{ .Branch }}-{{ checksum "/tmp/requirements-checksum" }}
+            - setup_badass_config:
+                  wd: <<parameters.wd>>
+            - steps: <<parameters.config>>
+            - run:
+                  name: "Create pip freeze file."
+                  command: |
+                      pip freeze > <<parameters.wd>>/pip.freeze
+                  when: always
+            - persist_to_workspace:
+                  root: ~/
+                  paths:
+                      - project
+                      - .venv
     badass_test_pre_spread:
         parameters:
-            wd:
-                description: "Where tests should be run in the repo, relative to the repodir (no trailing slash)."
-                type: string
-                default: ${CIRCLE_PROJECT_REPONAME}
-            setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
-                type: steps
-                default: []
-            config:
-                description: "Any additional BMS configuration steps."
-                type: steps
-                default: []
-            executor:
-                description: "Execution environment for the test job."
-                type: executor
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-            badge_label:
-                description: "The label to use for the badge."
-                type: string
-                default: tests
-            meta_job_name:
-                description: "The filename to use for the badge."
-                type: string
+            <<: *pre_spread_common_parameters
             pipenv_python_arg:
                 description: "Location or version of the python interpreter to use for pipenv."
                 type: string
@@ -225,6 +291,10 @@ jobs:
                 description: "Any additional BMS configuration steps."
                 type: steps
                 default: []
+            use_pipenv:
+                description: "run commands using pipenv"
+                type: boolean
+                default: true
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         parallelism: <<parameters.parallelism>>
@@ -243,6 +313,7 @@ jobs:
                   parallel: <<parameters.parallel>>
                   test_script: <<parameters.test_script>>
                   parallelism: <<parameters.parallelism>>
+                  use_pipenv: <<parameters.use_pipenv>>
             - run:
                   name: Success flag
                   when: on_success
@@ -262,6 +333,9 @@ jobs:
                       mkdir ~/workspace
                       cp <<parameters.wd>>/*.status ~/workspace/
                       cp <<parameters.wd>>/.coverage* ~/workspace/
+                      if [ -f <<parameters.wd>>/pip.freeze ]; then
+                          cp <<parameters.wd>>/pip.freeze ~/workspace/
+                      fi
             - persist_to_workspace:
                   root: ~/
                   paths:
@@ -294,6 +368,10 @@ jobs:
                 description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
                 type: steps
                 default: []
+            use_pipenv:
+                description: "Use pipenv to run commands."
+                type: boolean
+                default: true
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
@@ -325,8 +403,18 @@ jobs:
                   file: /tmp/status.svg
                   remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
                   host: docs
+            - when:
+                  condition:
+                      not: <<parameters.use_pipenv>>
+                  steps:
+                      - utils/rsync_file:
+                            when: always
+                            file: <<parameters.wd>>/pip.freeze
+                            remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.freeze
+                            host: docs
             - coverage_combine_and_html:
                   wd: <<parameters.wd>>
+                  use_pipenv: <<parameters.use_pipenv>>
             - utils/rsync_folder:
                   when: always
                   folder: <<parameters.wd>>/htmlcov/
@@ -422,6 +510,10 @@ commands:
             parallelism:
                 description: "The level of test parallelism via circleci splitting."
                 type: integer
+            use_pipenv:
+                description: "run commands using pipenv"
+                type: boolean
+                default: true
         steps:
             - run:
                   name: Run test suite, split by amount of circleci parallelism.
@@ -443,9 +535,9 @@ commands:
                           TESTFILES=$(echo $TESTFILES | tr "/" "." | sed 's/.py//g')
                       fi
                       if [ "<<parameters.parallel>>" -eq "0" ]; then
-                          pipenv run coverage run -p <<parameters.test_script>> $TESTFILES
+                          <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage run -p <<parameters.test_script>> $TESTFILES
                       else
-                          pipenv run coverage run -p <<parameters.test_script>> --parallel=<<parameters.parallel>> $TESTFILES
+                          <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage run -p <<parameters.test_script>> --parallel=<<parameters.parallel>> $TESTFILES
                       fi
             - store_test_results:
                   path: test-results
@@ -462,12 +554,17 @@ commands:
                 description: "coverage percent output file name."
                 type: string
                 default: "/tmp/.coveragep"
+            use_pipenv:
+                description: "run commands using pipenv"
+                type: boolean
+                default: true
         steps:
             - run:
                   name: Combine coverage and build reports
                   command: |
                       cd <<parameters.wd>>
-                      pipenv run coverage combine
-                      pipenv run coverage html
-                      pipenv run coverage report | grep -oP '^TOTAL.*\d' | awk '{print $NF}' >> <<parameters.coveragep>>
+                      <<^ parameters.use_pipenv>>pip install --user coverage[toml]<</ parameters.use_pipenv>>
+                      <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage combine
+                      <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage html
+                      <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage report | grep -oP '^TOTAL.*\d' | awk '{print $NF}' >> <<parameters.coveragep>>
                   when: always


### PR DESCRIPTION
We dropped support for tests using plain requirements.txt files with `arrai/badass@14.0.0`, however, we have several projects that haven't been switched to use pipenv. Since one can't release patch/minor updates for older major version releases on CircleCI, and I wanted to make use of fixed IP ranges, I've ported a variant of the old functionality to the current release.

This adds a new `badass_venv_test_pre_spread`. `badass_test_pre_spread` remains as the pipenv variant. `badass_test_spread` and `badass_test_combine` have been updated with a `use_pipenv` boolean that defaults to `true`. If set to `false`, pip is used instead of pipenv.

This has been published as `arrai/badass@17.2.0` as this is intended as a non-breaking change for projects already on v17.