### PR TITLE
fix: add ssh keys only when needed when running npm audit job

### DIFF
--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -116,9 +116,9 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.18
+            - image: cimg/node:18.19
     v20:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:20.9
+            - image: cimg/node:20.10

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -16,12 +16,12 @@ executors:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:18.18
+            - image: cimg/node:18.19
     v20:
         environment:
             LANG: en_US.UTF-8
         docker:
-            - image: cimg/node:20.9
+            - image: cimg/node:20.10
 aliases:
     common_audit_parameters: &common_audit_parameters
         wd:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -62,7 +62,6 @@ aliases:
             default: true
     common_audit_steps: &common_audit_steps
         - checkout
-        - utils/add_ssh_config
         - steps: <<parameters.setup>>
         - upgrade_npm
         - utils/add_npm_config
@@ -96,6 +95,7 @@ aliases:
                             else
                                 echo "export TOTAL_VULNERABILITIES=?" >> $BASH_ENV
                              fi
+                  - utils/add_ssh_config
                   - utils/make_status_shield:
                         when: on_fail
                         status: "${TOTAL_VULNERABILITIES}"

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -6,7 +6,7 @@ executors:
         environment:
             LANG: C.UTF-8
         docker:
-            - image: cimg/node:18.18-browsers
+            - image: cimg/node:18.19-browsers
 aliases:
     common_parameters: &common_parameters
         wd:

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,13 +204,13 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.2.0.tgz",
-      "integrity": "sha512-rgUPUQraHxoMLxiE8GK430HA7/R2vXyLcOT4fQooNrZq9ERutNrP6dw3gdKLkq22Nede3+gEHQYUzL4Wu75ndg==",
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.8.1.tgz",
+      "integrity": "sha512-UshMi4Ltb4ZlNn4F7WtSEugFDZmctzFpmbqvpyxD3la510J+PLcnyhf9chs7EryaRFJMdAKwsEKfNK0jL/QM4g==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
+        "@commitlint/types": "^17.8.1",
+        "semver": "7.5.4"
       },
       "engines": {
         "node": ">=v14"
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.8.1.tgz",
+      "integrity": "sha512-PXDQXkAmiMEG162Bqdh9ChML/GJZo6vU+7F03ALKDK8zYc6SuAr47LjG7hGYRqUOz+WK0dU7bQ0xzuqFMdxzeQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -2887,9 +2887,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -3100,9 +3100,9 @@
       ]
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -3965,13 +3965,13 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.2.0.tgz",
-      "integrity": "sha512-rgUPUQraHxoMLxiE8GK430HA7/R2vXyLcOT4fQooNrZq9ERutNrP6dw3gdKLkq22Nede3+gEHQYUzL4Wu75ndg==",
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.8.1.tgz",
+      "integrity": "sha512-UshMi4Ltb4ZlNn4F7WtSEugFDZmctzFpmbqvpyxD3la510J+PLcnyhf9chs7EryaRFJMdAKwsEKfNK0jL/QM4g==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
+        "@commitlint/types": "^17.8.1",
+        "semver": "7.5.4"
       }
     },
     "@commitlint/lint": {
@@ -4079,9 +4079,9 @@
       }
     },
     "@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+      "version": "17.8.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.8.1.tgz",
+      "integrity": "sha512-PXDQXkAmiMEG162Bqdh9ChML/GJZo6vU+7F03ALKDK8zYc6SuAr47LjG7hGYRqUOz+WK0dU7bQ0xzuqFMdxzeQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
@@ -5831,9 +5831,9 @@
           }
         },
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         },
         "type-fest": {
@@ -6036,9 +6036,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"


### PR DESCRIPTION
- `add_ssh_config` would run even when badges weren't being requested, this causes problems when the job is run without fixed IP addresses.
- bumped node images to the latest releases, published as:
  - `arrai/npm@2.12.2`
  - `arrai/prettier@5.8.1`
  - `arrai/eslint@7.9.1`