### PR TITLE
feat: allow the use of CA signed host keys when configuring the ssh c…

### DIFF
--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -61,7 +61,7 @@ commands:
                           sudo sed -i -e "s/^AccountID.*/AccountID $MAXMIND_ID/" -e "s/^LicenseKey.*/LicenseKey $MAXMIND_KEY/" /usr/local/etc/GeoIP.conf
                       fi
     add_ssh_config:
-        description: "Fetch host keys from a SSH server and generate ~/.ssh/config and ~/.ssh/known_hosts."
+        description: "Update ~/.ssh/config and ~/.ssh/known_hosts with server host keys or certificate authority details."
         parameters:
             host:
                 description: "The name of the entry in ~/.ssh/config to use as a short-hand in SSH commands."
@@ -79,14 +79,26 @@ commands:
                 description: "The user name to present to the remote SSH server."
                 type: string
                 default: ${DOCS_USER}
+            ca:
+                description: "Type and public key data of the CA that signed the server's host key; e.g. ed25519 AABBCCDD..."
+                type: string
+                default: ${SSH_CA}
+            hostkeyalgorithms:
+                description: "List of preferred host key algorithms."
+                type: string
+                default: "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519"
         steps:
             - run:
                   name: "Configure SSH Client"
                   command: |
                       touch ~/.ssh/config
                       if [ -n "<<parameters.hostname>>" ]; then
-                          ssh-keyscan -p <<parameters.port>> <<parameters.hostname>> >> ~/.ssh/known_hosts
-                          echo -e "Host <<parameters.host>>\n\tHostName <<parameters.hostname>>\n\tPort <<parameters.port>>\n\tUser <<parameters.user>>" >> ~/.ssh/config
+                          if [ -n "<<parameters.ca>>" ]; then
+                              echo "@cert-authority <<parameters.hostname>> <<parameters.ca>>" >> ~/.ssh/known_hosts
+                          else
+                              ssh-keyscan -p <<parameters.port>> <<parameters.hostname>> >> ~/.ssh/known_hosts
+                          fi
+                          echo -e "Host <<parameters.host>>\n\tHostName <<parameters.hostname>>\n\tPort <<parameters.port>>\n\tUser <<parameters.user>>\n\tHostKeyAlgorithms <<parameters.hostkeyalgorithms>>" >> ~/.ssh/config
                       fi
     make_status_shield:
         description: "Fetch status shield from shields.io."


### PR DESCRIPTION
…lient

We were previously just using `ssh-keyscan` to import the host keys from our docs server straight. This isn't ideal as it isn't any more secure than just trusting all host keys.

All ouf our servers use CA signed host keys, so instead of just importing the keys, we can configure the client the trust the CA.
The `add_ssh_config` command has been modified to allow the user to specify a CA via the `ca` parameter.

The fallback is to use `ssh-keyscan` if there's no CA configured.

This was published as `arrai/utils@1.15.0`