### PR TITLE
chore: fixes and optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # CircleCI Orbs
 
-![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=for-the-badge)
+[![badass: version][]](#badass)
+[![eslint: version][]](#eslint)
+[![flake8: version][]](#flake8)
+[![github: version][]](#github)
+[![npm: version][]](#npm)
+[![prettier: version][]](#prettier)
+[![pypi: version][]](#pypi)
+[![pytest: version][]](#pytest)
+[![sentry: version][]](#sentry)
+[![utils: version][]](#utils)
 
 This repository contains circleci orbs that Arrai Innovations publishes to the CircleCI Orb registry. While available for public consumption, these are tailored towards our CI process. These orbs are published into the _arrai_ namespace.
 
@@ -98,3 +107,14 @@ After making the requisite changes, you can check for syntactic validity by runn
 You can then publish a dev version of your Orb: `circleci orb publish example.yml arrai/example@dev:1`. You can now reference this Orb in project-specific configs or other Orbs. Unlike release Orbs, development Orbs are mutable and will be deleted after 90 days.
 
 Once you're ready to promote your Orb to release, determine whether this counts as a patch, minor, or major release; this will be passed into the promote command: `circleci orb publish promote arrai/example@dev:1 patch`. The command will return the version number used for the Orb; use this to reference the new Orb in your project CI configurations.
+
+[badass: version]: https://badges.circleci.com/orbs/arrai/badass.svg
+[eslint: version]: https://badges.circleci.com/orbs/arrai/eslint.svg
+[flake8: version]: https://badges.circleci.com/orbs/arrai/flake8.svg
+[github: version]: https://badges.circleci.com/orbs/arrai/github.svg
+[npm: version]: https://badges.circleci.com/orbs/arrai/npm.svg
+[prettier: version]: https://badges.circleci.com/orbs/arrai/prettier.svg
+[pypi: version]: https://badges.circleci.com/orbs/arrai/pypi.svg
+[pytest: version]: https://badges.circleci.com/orbs/arrai/pytest.svg
+[sentry: version]: https://badges.circleci.com/orbs/arrai/sentry.svg
+[utils: version]: https://badges.circleci.com/orbs/arrai/utils.svg

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
   - [prettier](#prettier)
   - [pypi](#pypi)
   - [pytest](#pytest)
-  - [utils](#utils)
   - [sentry](#sentry)
+  - [utils](#utils)
 - [Developing Orbs](#developing-orbs)
 - [Publishing Orbs](#publishing-orbs)
 
@@ -77,12 +77,6 @@ For information on configuration parameters, refer to the generated [documentati
 
 Provides generic test environment for pytest based tests that have dependencies installed using `pipenv`. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pytest).
 
-### utils
-
-![utils: version][]
-
-This orb provides utility functions such as status badging, file uploads, and ssh key import. This is required by the other orbs. For information on the available utility functions, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/utils).
-
 ### sentry
 
 ![sentry: version][]
@@ -94,6 +88,12 @@ Publish releases to [Sentry](https://sentry.io/). Note that the `create_release`
 -   It is assumed that repositories have been configured within the Sentry organisation so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).
 
 For information on how to override these defaults, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry). An [example configuration](/examples/sentry.yml) is provided in the [examples folder](/examples/).
+
+### utils
+
+![utils: version][]
+
+This orb provides utility functions such as status badging, file uploads, and ssh key import. This is required by the other orbs. For information on the available utility functions, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/utils).
 
 ## Developing Orbs
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
 # CircleCI Orbs
 
-[![badass: version][]](#badass)
-[![eslint: version][]](#eslint)
-[![flake8: version][]](#flake8)
-[![github: version][]](#github)
-[![npm: version][]](#npm)
-[![prettier: version][]](#prettier)
-[![pypi: version][]](#pypi)
-[![pytest: version][]](#pytest)
-[![sentry: version][]](#sentry)
-[![utils: version][]](#utils)
-
 This repository contains circleci orbs that Arrai Innovations publishes to the CircleCI Orb registry. While available for public consumption, these are tailored towards our CI process. These orbs are published into the _arrai_ namespace.
 
 _Note to contributors_: The Orb Registry is public; private data should be passed via variables configured in the CI interface or stored in the appropriate private repo.
@@ -40,29 +29,43 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
 
 ### badass
 
+![badass: version][]
+
 This Orb provides an environment for running our BMS/Django tests. Not likely to be useful for testing Django instances not built or based on BMS. For a description of the Orb, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/badass).
 
 ### eslint
+
+![eslint: version][]
 
 Runs eslint on project code. Note that any warnings are treated as job failures. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/eslint).
 
 ### flake8
 
+![flake8: version][]
+
 Provides functionality for running flake8 on project code. Everything is treated as an error. For a description of the Orb, available steps, parameters, etc, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/flake8).
 
 ### github
+
+![github: version][]
 
 Creates a release on GitHub. For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/github).
 
 ### npm
 
+![npm: version][]
+
 Provides npm utility functions. For information on available functions and configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm).
 
 ### prettier
 
+![prettier: version][]
+
 Provides functionality for running prettier on project code. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/prettier).
 
 ### pypi
+
+![pypi: version][]
 
 Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and stashes the dist folder in a cache. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
 
@@ -70,13 +73,19 @@ For information on configuration parameters, refer to the generated [documentati
 
 ### pytest
 
+![pytest: version][]
+
 Provides generic test environment for pytest based tests that have dependencies installed using `pipenv`. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pytest).
 
 ### utils
 
+![utils: version][]
+
 This orb provides utility functions such as status badging, file uploads, and ssh key import. This is required by the other orbs. For information on the available utility functions, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/utils).
 
 ### sentry
+
+![sentry: version][]
 
 Publish releases to [Sentry](https://sentry.io/). Note that the `create_release` job uses the following defaults when creating releases:
 
@@ -85,7 +94,6 @@ Publish releases to [Sentry](https://sentry.io/). Note that the `create_release`
 -   It is assumed that repositories have been configured within the Sentry organisation so that commits can be associated with the release. Refer to the [Sentry documentation on this matter](https://docs.sentry.io/product/cli/releases/#sentry-cli-commit-integration).
 
 For information on how to override these defaults, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry). An [example configuration](/examples/sentry.yml) is provided in the [examples folder](/examples/).
-
 
 ## Developing Orbs
 

--- a/README.md
+++ b/README.md
@@ -29,43 +29,43 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
 
 ### badass
 
-![badass: version][]
+[![badass: version][]](https://circleci.com/orbs/registry/orb/arrai/badass)
 
 This Orb provides an environment for running our BMS/Django tests. Not likely to be useful for testing Django instances not built or based on BMS. For a description of the Orb, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/badass).
 
 ### eslint
 
-![eslint: version][]
+[![eslint: version][]](https://circleci.com/orbs/registry/orb/arrai/eslint)
 
 Runs eslint on project code. Note that any warnings are treated as job failures. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/eslint).
 
 ### flake8
 
-![flake8: version][]
+[![flake8: version][]](https://circleci.com/orbs/registry/orb/arrai/flake8)
 
 Provides functionality for running flake8 on project code. Everything is treated as an error. For a description of the Orb, available steps, parameters, etc, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/flake8).
 
 ### github
 
-![github: version][]
+[![github: version][]](https://circleci.com/orbs/registry/orb/arrai/github)
 
 Creates a release on GitHub. For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/github).
 
 ### npm
 
-![npm: version][]
+[![npm: version][]](https://circleci.com/orbs/registry/orb/arrai/npm)
 
 Provides npm utility functions. For information on available functions and configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm).
 
 ### prettier
 
-![prettier: version][]
+[![prettier: version][]](https://circleci.com/orbs/registry/orb/arrai/prettier)
 
 Provides functionality for running prettier on project code. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/prettier).
 
 ### pypi
 
-![pypi: version][]
+[![pypi: version][]](https://circleci.com/orbs/registry/orb/arrai/pypi)
 
 Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and stashes the dist folder in a cache. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
 
@@ -73,13 +73,13 @@ For information on configuration parameters, refer to the generated [documentati
 
 ### pytest
 
-![pytest: version][]
+[![pytest: version][]](https://circleci.com/orbs/registry/orb/arrai/pytest)
 
 Provides generic test environment for pytest based tests that have dependencies installed using `pipenv`. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pytest).
 
 ### sentry
 
-![sentry: version][]
+[![sentry: version][]](https://circleci.com/orbs/registry/orb/arrai/sentry)
 
 Publish releases to [Sentry](https://sentry.io/). Note that the `create_release` job uses the following defaults when creating releases:
 
@@ -91,7 +91,7 @@ For information on how to override these defaults, refer to the generated [docum
 
 ### utils
 
-![utils: version][]
+[![utils: version][]](https://circleci.com/orbs/registry/orb/arrai/utils)
 
 This orb provides utility functions such as status badging, file uploads, and ssh key import. This is required by the other orbs. For information on the available utility functions, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/utils).
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
   - [badass](#badass)
   - [eslint](#eslint)
   - [flake8](#flake8)
+  - [github](#github)
+  - [npm](#npm)
   - [prettier](#prettier)
+  - [pypi](#pypi)
   - [pytest](#pytest)
   - [utils](#utils)
-  - [npm](#npm)
   - [sentry](#sentry)
-  - [pypi](#pypi)
-  - [github](#github)
 - [Developing Orbs](#developing-orbs)
 - [Publishing Orbs](#publishing-orbs)
 
@@ -50,9 +50,23 @@ Runs eslint on project code. Note that any warnings are treated as job failures.
 
 Provides functionality for running flake8 on project code. Everything is treated as an error. For a description of the Orb, available steps, parameters, etc, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/flake8).
 
+### github
+
+Creates a release on GitHub. For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/github).
+
+### npm
+
+Provides npm utility functions. For information on available functions and configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm).
+
 ### prettier
 
 Provides functionality for running prettier on project code. For more details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/prettier).
+
+### pypi
+
+Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and stashes the dist folder in a cache. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
+
+For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pypi).
 
 ### pytest
 
@@ -61,10 +75,6 @@ Provides generic test environment for pytest based tests that have dependencies 
 ### utils
 
 This orb provides utility functions such as status badging, file uploads, and ssh key import. This is required by the other orbs. For information on the available utility functions, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/utils).
-
-### npm
-
-Provides npm utility functions. For information on available functions and configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm).
 
 ### sentry
 
@@ -76,15 +86,6 @@ Publish releases to [Sentry](https://sentry.io/). Note that the `create_release`
 
 For information on how to override these defaults, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/sentry). An [example configuration](/examples/sentry.yml) is provided in the [examples folder](/examples/).
 
-### pypi
-
-Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and stashes the dist folder in a cache. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
-
-For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pypi).
-
-### github
-
-Creates a release on GitHub. For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/github).
 
 ## Developing Orbs
 

--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.15.0
+    utils: arrai/utils@1.16.0
 aliases:
     pre_spread_common_parameters: &pre_spread_common_parameters
         wd:

--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 aliases:
     pre_spread_common_parameters: &pre_spread_common_parameters
         wd:

--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -92,7 +92,6 @@ jobs:
         working_directory: <<parameters.repodir>>
         steps:
             - checkout
-            - utils/add_maxmind_config
             - utils/add_ssh_config
             - utils/make_status_shield:
                   status: running
@@ -320,7 +319,6 @@ jobs:
         working_directory: <<parameters.repodir>>
         steps:
             - checkout
-            - utils/add_maxmind_config
             - steps: <<parameters.setup>>
             - attach_workspace:
                   at: ~/

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 commands:
     upgrade_npm:
         steps:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,17 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.15.0
-commands:
-    upgrade_npm:
-        steps:
-            - run:
-                  name: "Install the latest npm"
-                  command: |
-                      if [ "$(which npm)" = "/usr/local/bin/npm" ]; then
-                          sudo npm install -g --upgrade npm
-                      else
-                          npm install -g --upgrade npm
-                      fi
+    utils: arrai/utils@1.16.0
 aliases:
     common_parameters: &common_parameters
         wd:
@@ -43,10 +32,15 @@ aliases:
             description: "Generate badges."
             type: boolean
             default: true
+        npm_version:
+            description: "NPM version to use"
+            type: string
+            default: "latest"
     common_steps: &common_steps
         - checkout
         - steps: <<parameters.setup>>
-        - upgrade_npm
+        - utils/upgrade_npm:
+              version: <<parameters.npm_version>>
         - utils/add_npm_config
         - steps: <<parameters.config>>
         - run:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -25,7 +25,7 @@ aliases:
         executor:
             description: "The executor to use for the job."
             type: executor
-            default: v18
+            default: lts
         resource_class:
             description: "The resource class to use for the job."
             type: enum
@@ -112,13 +112,3 @@ executors:
             LANG: en_US.UTF-8
         docker:
             - image: cimg/node:current
-    v18:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:18.19
-    v20:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:20.10

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -2,6 +2,12 @@ version: 2.1
 orbs:
     utils: arrai/utils@1.15.0
 executors:
+    python312:
+        docker:
+            - image: cimg/python:3.12
+    python311:
+        docker:
+            - image: cimg/python:3.11
     python310:
         docker:
             - image: cimg/python:3.10
@@ -11,9 +17,6 @@ executors:
     python38:
         docker:
             - image: cimg/python:3.8
-    python36:
-        docker:
-            - image: cimg/python:3.6
 aliases:
     common_parameters: &common_parameters
         flake8_cmd:

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 executors:
     python310:
         docker:

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.15.0
+    utils: arrai/utils@1.16.0
 executors:
     python312:
         docker:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 executors:
     lts:
         environment:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -12,16 +12,6 @@ executors:
             LANG: en_US.UTF-8
         docker:
             - image: cimg/node:current
-    v18:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:18.19
-    v20:
-        environment:
-            LANG: en_US.UTF-8
-        docker:
-            - image: cimg/node:20.10
 aliases:
     common_audit_parameters: &common_audit_parameters
         wd:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.15.0
+    utils: arrai/utils@1.16.0
 executors:
     lts:
         environment:
@@ -57,7 +57,7 @@ aliases:
     common_audit_steps: &common_audit_steps
         - checkout
         - steps: <<parameters.setup>>
-        - upgrade_npm:
+        - utils/upgrade_npm:
               version: <<parameters.npm_version>>
         - utils/add_npm_config
         - steps: <<parameters.config>>
@@ -108,22 +108,6 @@ aliases:
                         file: ~/status.svg
                         remote_file: ${CIRCLE_BRANCH}/npm-audit.svg
                         host: docs
-commands:
-    upgrade_npm:
-        parameters:
-            version:
-                description: "NPM version to use"
-                type: string
-                default: "latest"
-        steps:
-            - run:
-                  name: "Install/Update npm"
-                  command: |
-                      if [ "$(which npm)" = "/usr/local/bin/npm" ]; then
-                          sudo npm install -g npm@<<parameters.version>>
-                      else
-                          npm install -g npm@<<parameters.version>>
-                      fi
 jobs:
     audit:
         parameters:
@@ -180,7 +164,7 @@ jobs:
             - checkout
             - utils/add_ssh_config
             - steps: <<parameters.setup>>
-            - upgrade_npm:
+            - utils/upgrade_npm:
                   version: <<parameters.npm_version>>
             - utils/add_npm_config
             - steps: <<parameters.config>>
@@ -259,7 +243,7 @@ jobs:
         steps:
             - checkout
             - steps: <<parameters.setup>>
-            - upgrade_npm:
+            - utils/upgrade_npm:
                   version: <<parameters.npm_version>>
             - utils/add_npm_config
             - run:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.15.0
+    utils: arrai/utils@1.16.0
 executors:
     node:
         environment:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 executors:
     node18:
         environment:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -2,11 +2,11 @@ version: 2.1
 orbs:
     utils: arrai/utils@1.15.0
 executors:
-    node18:
+    node:
         environment:
             LANG: C.UTF-8
         docker:
-            - image: cimg/node:18.19-browsers
+            - image: cimg/node:lts-browsers
 aliases:
     common_parameters: &common_parameters
         wd:
@@ -16,7 +16,7 @@ aliases:
         executor:
             description: "The executor to use for the job."
             type: executor
-            default: node18
+            default: node
         resource_class:
             description: "The resource class to use for the job."
             type: enum

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -3,7 +3,7 @@ description: |
     This job requires `pytest-cov` and `coverage` to be installed as `pipenv` `devDependences`.
     Configure pytest and coverage via pyproject.toml.
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 executors:
     python310:
         docker:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -3,7 +3,7 @@ description: |
     This job requires `pytest-cov` and `coverage` to be installed as `pipenv` `devDependences`.
     Configure pytest and coverage via pyproject.toml.
 orbs:
-    utils: arrai/utils@1.15.0
+    utils: arrai/utils@1.16.0
 executors:
     python312:
         docker:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -5,6 +5,12 @@ description: |
 orbs:
     utils: arrai/utils@1.15.0
 executors:
+    python312:
+        docker:
+            - image: cimg/python:3.12
+    python311:
+        docker:
+            - image: cimg/python:3.11
     python310:
         docker:
             - image: cimg/python:3.10
@@ -14,9 +20,6 @@ executors:
     python38:
         docker:
             - image: cimg/python:3.8
-    python36:
-        docker:
-            - image: cimg/python:3.6
 jobs:
     pytest:
         parameters:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.14.0
+    utils: arrai/utils@1.15.0
 executors:
     python310:
         docker:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -2,6 +2,12 @@ version: 2.1
 orbs:
     utils: arrai/utils@1.15.0
 executors:
+    python312:
+        docker:
+            - image: cimg/python:3.12
+    python311:
+        docker:
+            - image: cimg/python:3.11
     python310:
         docker:
             - image: cimg/python:3.10
@@ -11,9 +17,6 @@ executors:
     python38:
         docker:
             - image: cimg/python:3.8
-    python36:
-        docker:
-            - image: cimg/python:3.6
 aliases:
     common_parameters: &common_parameters
         executor:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.15.0
+    utils: arrai/utils@1.16.0
 executors:
     python312:
         docker:

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -158,8 +158,6 @@ commands:
                         "flat",
                         "flat-square",
                         "for-the-badge",
-                        "popout",
-                        "popout-square",
                         "social",
                     ]
                 default: for-the-badge

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -295,3 +295,19 @@ commands:
                   name: "Inject NPM_TOKEN into config"
                   command: |
                       echo "//<<parameters.registry>>/:_authToken=<<parameters.token>>" > ~/.npmrc
+    upgrade_npm:
+        description: "Install / Upgrade npm"
+        parameters:
+            version:
+                description: "NPM version to use"
+                type: string
+                default: "latest"
+        steps:
+            - run:
+                  name: "Install/Update npm"
+                  command: |
+                      if [ "$(which npm)" = "/usr/local/bin/npm" ]; then
+                          sudo npm install -g npm@<<parameters.version>>
+                      else
+                          npm install -g npm@<<parameters.version>>
+                      fi


### PR DESCRIPTION
- add dynamic orb version badges so that the latest releases can be more easily identified
- reorder the docs into alphabetical order
- bump to the latest utils orb to take advantage of fixes to `add_ssh_config`
- remove the `add_maxmind_config` steps from the `badass` orb; it's no longer required. The docker images have been updated with a version of `geoipupdate` that can take in configuration options via environment variables. These are set via the `arrai-maxmind` context.
- switched to only having `current` and `lts` node executors in the orbs and default to `lts`. Having fixed version numbers in the orbs doesn't make much sense;  if a workflow needs a specific version, it should be set via an overriding executor.
- dropped python 3.6 and added 3.11 and 3.12 to the available python executors where needed to align with the current upstream support matrix
- moved the `npm_upgrade` command into the `utils` orb since it's used in other orbs and we have that command duplicated in places; this is a breaking change.

new versions:
- `arrai/badass@17.5.0`
- `arrai/eslint@7.10.0`
- `arrai/flake8@19.0.0` - breaking for any workflow using the `flake8/python36` executor
- `arrai/npm@3.0.0` - breaking for any workflow is using `npm/upgrade_npm` or the `npm/v18` or `npm/v20` executors
- `arrai/prettier@5.9.0`
- `arrai/pytest@8.0.0` - breaking for any workflow using the `pytest/python36` executor
- `arrai/safety@3.0.0` -breaking for any workflow using the `safety/python36` executor
- `arrai/utils@1.16.0`