### PR TITLE
feat: use the python version in cache-key generation

### DIFF
--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -78,7 +78,6 @@ aliases:
         - steps: <<parameters.setup>>
         - setup_flake8_pipenv:
               wd: <<parameters.wd>>
-              pipenv_meta_job_name: <<parameters.pipenv_meta_job_name>>
               pipenv_cache_key_version: <<parameters.pipenv_cache_key_version>>
         - flake8_errors_pipenv:
               flake8_cmd: <<parameters.flake8_cmd>>
@@ -116,9 +115,6 @@ jobs:
     flake8_pipenv:
         parameters:
             <<: *common_parameters
-            pipenv_meta_job_name:
-                description: "a test job's meta job name for sharing pipenv cache."
-                type: string
             pipenv_cache_key_version:
                 description: "a string that can be changed to bust the pipenv cache."
                 type: string
@@ -132,9 +128,6 @@ jobs:
     flake8_pipenv_fixed_ip:
         parameters:
             <<: *common_parameters
-            pipenv_meta_job_name:
-                description: "a test job's meta job name for sharing pipenv cache."
-                type: string
             pipenv_cache_key_version:
                 description: "a string that can be changed to bust the pipenv cache."
                 type: string
@@ -185,18 +178,19 @@ commands:
         parameters:
             wd:
                 type: string
-            pipenv_meta_job_name:
-                description: "a test job's meta job name for sharing pipenv cache."
-                type: string
             pipenv_cache_key_version:
                 description: "a string that can be changed to bust the pipenv cache."
                 type: string
         steps:
+            - run:
+                  name: Keep track of the python version.
+                  command: |
+                      python --version > /tmp/python.version
             - restore_cache: # ensure this step occurs *before* installing dependencies
                   keys:
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.pipenv_meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.pipenv_meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.pipenv_meta_job_name>>-<<parameters.pipenv_cache_key_version>>-main
+                      - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+                      - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
+                      - pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-main
             - run:
                   name: "Set up python virtual environment."
                   command: |
@@ -205,7 +199,7 @@ commands:
             - save_cache:
                   paths:
                       - ~/.local/share/virtualenvs/
-                  key: pipenv-{{ checksum "/etc/os-release" }}-<<parameters.pipenv_meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+                  key: pipenv-{{ checksum "/etc/os-release" }}-{{ checksum "/tmp/python.version" }}-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
     flake8_errors_pipenv:
         description: "Run flake8, checking for errors only."
         parameters:


### PR DESCRIPTION
Published as `arrai/flake8@20.0.0`.