### PR TITLE
fix: make rsync_install respect the when parameter

### DIFF
--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -201,9 +201,14 @@ commands:
             requires_sudo:
                 type: boolean
                 default: true
+            when:
+                type: enum
+                enum: ["always", "on_success", "on_fail"]
+                default: on_success
         steps:
             - run:
                   name: install rsync
+                  when: <<parameters.when>>
                   command: |
                       if ! [ -x "$(command -v rsync)" ]; then
                           if [ -f /usr/bin/yum ]; then
@@ -235,6 +240,7 @@ commands:
         steps:
             - rsync_install:
                   requires_sudo: <<parameters.requires_sudo>>
+                  when: <<parameters.when>>
             - run:
                   name: rsync file (<<parameters.file>> -> <<parameters.remote_file>>)
                   command: |
@@ -276,6 +282,7 @@ commands:
         steps:
             - rsync_install:
                   requires_sudo: <<parameters.requires_sudo>>
+                  when: <<parameters.when>>
             - run:
                   name: rsync folder (<<parameters.folder>> -> <<parameters.remote_folder>>)
                   command: |


### PR DESCRIPTION
The `install_rsync` function wasn't sensitive to the `when:` parameter. Since the default for this parameter is `on_success`, rsync would fail to get installed if any previous step had set a failure condition. This could result in error badges not being uploaded.

Fix published as `arrai/utils@1.16.2`. We'll bump all the orbs with this version in a subsequent PR.