### PR TITLE
chore: bump utils orb to latest release

### DIFF
--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 aliases:
     pre_spread_common_parameters: &pre_spread_common_parameters
         wd:

--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 aliases:
     pre_spread_common_parameters: &pre_spread_common_parameters
         wd:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 aliases:
     common_parameters: &common_parameters
         wd:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 aliases:
     common_parameters: &common_parameters
         wd:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -79,7 +79,7 @@ aliases:
                         when: always
                         file: ~/status.svg
                         remote_file: $CIRCLE_BRANCH/$CIRCLE_JOB.svg
-                        host: doc
+                        host: docs
 jobs:
     eslint:
         parameters:

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 executors:
     python312:
         docker:

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 executors:
     python312:
         docker:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 executors:
     lts:
         environment:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 executors:
     lts:
         environment:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 executors:
     node:
         environment:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 executors:
     node:
         environment:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -3,7 +3,7 @@ description: |
     This job requires `pytest-cov` and `coverage` to be installed as `pipenv` `devDependences`.
     Configure pytest and coverage via pyproject.toml.
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 executors:
     python312:
         docker:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -3,7 +3,7 @@ description: |
     This job requires `pytest-cov` and `coverage` to be installed as `pipenv` `devDependences`.
     Configure pytest and coverage via pyproject.toml.
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 executors:
     python312:
         docker:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.2
+    utils: arrai/utils@1.16.3
 executors:
     python312:
         docker:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.1
+    utils: arrai/utils@1.16.2
 executors:
     python312:
         docker:

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -87,6 +87,10 @@ commands:
                 description: "List of preferred host key algorithms."
                 type: string
                 default: "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519"
+            when:
+                type: enum
+                enum: ["always", "on_success", "on_fail"]
+                default: always
         steps:
             - run:
                   name: "Configure SSH Client"
@@ -100,6 +104,7 @@ commands:
                           fi
                           echo -e "Host <<parameters.host>>\n\tHostName <<parameters.hostname>>\n\tPort <<parameters.port>>\n\tUser <<parameters.user>>\n\tHostKeyAlgorithms <<parameters.hostkeyalgorithms>>" >> ~/.ssh/config
                       fi
+                  when: <<parameters.when>>
     make_status_shield:
         description: "Fetch status shield from shields.io."
         parameters:


### PR DESCRIPTION
Bumped the utils orb to the latest fixed release in all the other orbs. This resulted in the following releases:

`arrai/badass@17.5.2`
`arrai/eslint@7.10.2`
`arrai/flake8@20.0.1`
`arrai/npm@3.0.2`
`arrai/prettier@5.9.2`
`arrai/pytest@8.1.3`
`arrai/safety@3.0.2`
