### PR TITLE
feat: run npm install before lintint; in case the user wants to use a…

### DIFF
--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -36,6 +36,10 @@ aliases:
             description: "NPM version to use"
             type: string
             default: "latest"
+        npm_install:
+            description: "Run npm install prior to lintint"
+            type: boolean
+            default: true
     common_steps: &common_steps
         - checkout
         - steps: <<parameters.setup>>
@@ -43,6 +47,14 @@ aliases:
               version: <<parameters.npm_version>>
         - utils/add_npm_config
         - steps: <<parameters.config>>
+        - when:
+              condition: <<parameters.npm_install>>
+              steps:
+                  - run:
+                        name: Run npm install
+                        command: |
+                            cd <<parameters.wd>>
+                            npm install --include dev
         - run:
               name: Run eslint
               command: |


### PR DESCRIPTION
… package locked version of eslint

The configuration format changed in eslint 9 in incompatible ways. Since this orb simply runs `npx eslint`, it'll always run with the latest version of eslint, which is unlikely to work if the project was configured with eslint 8 in mind. This PR adds a config option to run `npm install --include dev` before linting. This will install any eslint version that might be in the package.json, which npx will then use instead. 

This has been published as `arrai/eslint@8.0.0`, as the `npm_install` boolean defaults to `true`, changing the default behaviour. In our cases it's likely to do TheRightThing, so this default makes the most sense.