### PR TITLE
fix: run pipenv clean to remove extraneous packages

### DIFF
--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -195,6 +195,7 @@ commands:
                   name: "Set up python virtual environment."
                   command: |
                       cd <<parameters.wd>>
+                      pipenv clean
                       pipenv sync --dev | cat; test ${PIPESTATUS[0]} -eq 0
             - save_cache:
                   paths:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -91,6 +91,7 @@ jobs:
                   name: Setup pipenv environment.
                   command: |
                       cd <<parameters.wd>>
+                      pipenv clean
                       pipenv sync --dev | cat; test ${PIPESTATUS[0]} -eq 0
                       echo "import coverage; coverage.process_startup()" > `pipenv run python -c "import sys; print([x for x in sys.path if x.find('.local/share/virtualenvs') != -1 and x.find('site-packages') != -1][0] + '/coverage-all-the-things.pth')"`
             - save_cache:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -64,6 +64,7 @@ aliases:
               name: Set up python environment
               command: |
                   pip list --outdated --format=json | jq -r '.[]|.name' | xargs -r pip install -U
+                  pipenv clean
                   pipenv sync | cat; test ${PIPESTATUS[0]} -eq 0
         - save_cache:
               paths:


### PR DESCRIPTION
We weren't cleaning up packages that were no longer listed in the lock file, which could lead to problems when restoring from cache.

Released as:
`arrai/eslint@8.0.1`
`arrai/pytest@8.1.5`
`arrai/safety@3.0.4`