### PR TITLE
feat: echo rsync command line

### DIFF
--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 aliases:
     pre_spread_common_parameters: &pre_spread_common_parameters
         wd:

--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 aliases:
     common_parameters: &common_parameters
         wd:

--- a/orbs/flake8.yml
+++ b/orbs/flake8.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 executors:
     python312:
         docker:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 executors:
     lts:
         environment:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 executors:
     node:
         environment:

--- a/orbs/pytest.yml
+++ b/orbs/pytest.yml
@@ -3,7 +3,7 @@ description: |
     This job requires `pytest-cov` and `coverage` to be installed as `pipenv` `devDependences`.
     Configure pytest and coverage via pyproject.toml.
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 executors:
     python312:
         docker:

--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.16.3
+    utils: arrai/utils@1.18.0
 executors:
     python312:
         docker:

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -255,6 +255,7 @@ commands:
                           if [ "${MATCH}" -gt "0" ]; then
                               LANG=en_US.UTF-8
                               REMOTE_FILE=$(printf %q "<<parameters.remote_file>>")
+                              set -x
                               rsync -t -e "ssh" <<parameters.file>> "<<parameters.host>>:/${REMOTE_FILE}"
                           fi
                       fi
@@ -295,6 +296,7 @@ commands:
                           if [ "${MATCH}" -gt "0" ]; then
                               LANG=en_US.UTF-8
                               REMOTE_FOLDER=$(printf %q "<<parameters.remote_folder>>")
+                              set -x
                               rsync <<# parameters.delete>>--delete<</ parameters.delete>> -r -l -t -e "ssh" <<parameters.folder>> "<<parameters.host>>:/${REMOTE_FOLDER}"
                           fi
                       fi

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -253,11 +253,9 @@ commands:
                           set +e
                           MATCH=$(grep -Pc "^Host <<parameters.host>>$" ~/.ssh/config)
                           if [ "${MATCH}" -gt "0" ]; then
-                              OLD_LANG="${LANG}"
                               LANG=en_US.UTF-8
                               REMOTE_FILE=$(printf %q "<<parameters.remote_file>>")
                               rsync -t -e "ssh" <<parameters.file>> "<<parameters.host>>:/${REMOTE_FILE}"
-                              LANG="${OLD_LANG}"
                           fi
                       fi
                   when: <<parameters.when>>
@@ -295,11 +293,9 @@ commands:
                           set +e
                           MATCH=$(grep -Pc "^Host <<parameters.host>>$" ~/.ssh/config)
                           if [ "${MATCH}" -gt "0" ]; then
-                              OLD_LANG="${LANG}"
                               LANG=en_US.UTF-8
                               REMOTE_FOLDER=$(printf %q "<<parameters.remote_folder>>")
                               rsync <<# parameters.delete>>--delete<</ parameters.delete>> -r -l -t -e "ssh" <<parameters.folder>> "<<parameters.host>>:/${REMOTE_FOLDER}"
-                              LANG="${OLD_LANG}"
                           fi
                       fi
                   when: <<parameters.when>>


### PR DESCRIPTION
- Spit out the `rsync` command line as a convenience.
- Remove the re-setting of the `LANG` environment variable. This does nothing useful at the moment; no subsequent commands run in the step and environment variables don't carry over to the next step.

The version of the utils orb was bumped to 1.18.0. The dependencies in the other orbs were updated and released as the following:

- `arrai/badass@17.6.0`
- `arrai/eslint@8.1.0`
- `arrai/flake8@20.1.0`
- `arrai/npm@3.1.0`
- `arrai/prettier@5.10.0`
- `arrai/pytest@8.2.0`
- `arrai/safety@3.1.0`
