### PR TITLE
feat: add command to check if changelog was updated between tags

### DIFF
--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -369,6 +369,6 @@ commands:
                       fi
                       HAS_COMMIT=$(git diff "${PREVIOUS_TAG}..${CIRCLE_TAG}" --name-only | grep -F <<parameters.changelog>>)
                       if [ -z "${HAS_COMMIT}" ]; then
-                          echo "<<parameters.changelog>> has not been updated for this tag."
+                          echo "<<parameters.changelog>> has not been updated between ${PREVIOUS_TAG} and ${CIRCLE_TAG}."
                           exit 1
                       fi

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -347,3 +347,25 @@ commands:
                       wget https://github.com/jwilder/dockerize/releases/download/<<parameters.version>>/dockerize-linux-amd64-<<parameters.version>>.tar.gz
                       sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-<<parameters.version>>.tar.gz
                       rm dockerize-linux-amd64-<<parameters.version>>.tar.gz
+    verify_changelog:
+        description: "Make sure the changelog was updated between tags."
+        parameters:
+            changelog:
+                description: "Path to the changelog."
+                type: string
+                default: "CHANGELOG.md"
+        steps:
+            - run:
+                  name: "Make sure the changelog was updated."
+                  command: |
+                      if ! [ -f <<parameters.changelog>> ]; then
+                          exit 0
+                      fi
+                      TAGS=($(git tag --list --sort=-creatordate --merged))
+                      if [ ${#TAGS[@]} -lt 2 ]; then
+                          exit 0
+                      fi
+                      HAS_COMMIT=$(git diff "${TAGS[1]}..${CIRCLE_TAG}" --name-only | grep -F <<parameters.changelog>>)
+                      if [ -z "${HAS_COMMIT}" ]; then
+                          exit 1
+                      fi

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -359,13 +359,16 @@ commands:
                   name: "Make sure the changelog was updated."
                   command: |
                       if ! [ -f <<parameters.changelog>> ]; then
+                          echo "No changelog found at <<parameters.changelog>>. Skipping check."
                           exit 0
                       fi
                       TAGS=($(git tag --list --sort=-creatordate --merged))
                       if [ ${#TAGS[@]} -lt 2 ]; then
+                          echo "No previous tag found. Nothing to compare against."
                           exit 0
                       fi
                       HAS_COMMIT=$(git diff "${TAGS[1]}..${CIRCLE_TAG}" --name-only | grep -F <<parameters.changelog>>)
                       if [ -z "${HAS_COMMIT}" ]; then
+                          echo "<<parameters.changelog>> has not been updated for this tag."
                           exit 1
                       fi

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -362,12 +362,12 @@ commands:
                           echo "No changelog found at <<parameters.changelog>>. Skipping check."
                           exit 0
                       fi
-                      TAGS=($(git tag --list --sort=-creatordate --merged))
-                      if [ ${#TAGS[@]} -lt 2 ]; then
+                      PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${CIRCLE_TAG}^" 2> /dev/null || true)
+                      if [ -z "${PREVIOUS_TAG}" ]; then
                           echo "No previous tag found. Nothing to compare against."
                           exit 0
                       fi
-                      HAS_COMMIT=$(git diff "${TAGS[1]}..${CIRCLE_TAG}" --name-only | grep -F <<parameters.changelog>>)
+                      HAS_COMMIT=$(git diff "${PREVIOUS_TAG}..${CIRCLE_TAG}" --name-only | grep -F <<parameters.changelog>>)
                       if [ -z "${HAS_COMMIT}" ]; then
                           echo "<<parameters.changelog>> has not been updated for this tag."
                           exit 1

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -347,7 +347,7 @@ commands:
                       wget https://github.com/jwilder/dockerize/releases/download/<<parameters.version>>/dockerize-linux-amd64-<<parameters.version>>.tar.gz
                       sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-<<parameters.version>>.tar.gz
                       rm dockerize-linux-amd64-<<parameters.version>>.tar.gz
-    verify_changelog:
+    require_changelog_between_tags:
         description: "Make sure the changelog was updated between tags."
         parameters:
             changelog:


### PR DESCRIPTION
Not sure about the command naming. Thoughts?

The logic is as follows:
- If there is no changelog; return success. Maybe it was deleted.
- If there is only one tag, return success since there can be no changes.
- If the `git diff` between the current and last tag doesn't contain the changelog, error.

Currently just published as `arrai/utils@dev:101`