### PR TITLE
fix: pin pipenv to a release that bundles safety 2.x

### DIFF
--- a/orbs/safety.yml
+++ b/orbs/safety.yml
@@ -53,7 +53,7 @@ aliases:
         - run:
               name: Set up python environment
               command: |
-                  pip list --outdated --format=json | jq -r '.[]|.name' | xargs -r pip install -U
+                  pip install pipenv==2024.4.0
         - steps: <<parameters.config>>
         - run:
               name: Run audit


### PR DESCRIPTION
Pin to a version of `pipenv` that bundles safety 2.x to preserve compatability with the `pipenv --check` command.

Published as `arrai/safety@4.1.0`