### PR TITLE
Switch to uv as the package manager for setting up badass tests

### DIFF
--- a/orbs/badass.yml
+++ b/orbs/badass.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.18.0
+    utils: arrai/utils@1.19.0
 aliases:
     pre_spread_common_parameters: &pre_spread_common_parameters
         wd:
@@ -41,7 +41,7 @@ jobs:
                 type: string
                 default: ${CIRCLE_PROJECT_REPONAME}
             setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+                description: "Any additional setup steps to run (e.g., dnf -y install foo-bar-baz)."
                 type: steps
                 default: []
             config:
@@ -70,22 +70,10 @@ jobs:
                 description: "The test script to run (e.g., manage.py test)."
                 type: string
                 default: manage.py test
-            pipenv_python_arg:
-                description: "Location or version of the python interpreter to use for pipenv."
+            python_version:
+                description: "Version of the python interpreter to use for uv."
                 type: string
                 default: ""
-            pipenv_skip_lock:
-                description: "Skip use of the pipenv lock file."
-                type: boolean
-                default: false
-            pip_install_args:
-                description: "Any additional arguments to pip install (e.g., -r ./requirements.txt)."
-                type: string
-                default: ""
-            use_pipenv:
-                description: "Run commands using pipenv"
-                type: boolean
-                default: true
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
@@ -103,18 +91,8 @@ jobs:
                   remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
                   host: docs
             - steps: <<parameters.setup>>
-            - when:
-                  condition: <<parameters.use_pipenv>>
-                  steps:
-                      - setup_pipenv:
-                            pipenv_python_arg: <<parameters.pipenv_python_arg>>
-                            pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
-            - when:
-                  condition:
-                      not: <<parameters.use_pipenv>>
-                  steps:
-                      - setup_venv:
-                            pip_install_args: <<parameters.pip_install_args>>
+            - setup_venv:
+                  python_version: <<parameters.python_version>>
             - setup_badass_config:
                   wd: <<parameters.wd>>
             - steps: <<parameters.config>>
@@ -122,10 +100,8 @@ jobs:
                   wd: <<parameters.wd>>
                   parallel: <<parameters.parallel>>
                   test_script: <<parameters.test_script>>
-                  use_pipenv: <<parameters.use_pipenv>>
             - coverage_combine_and_html:
                   wd: <<parameters.wd>>
-                  use_pipenv: <<parameters.use_pipenv>>
             - store_test_results:
                   path: test-results
             - store_artifacts:
@@ -161,82 +137,15 @@ jobs:
                   file: ~/status.svg
                   remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
                   host: docs
-    badass_venv_test_pre_spread:
-        parameters:
-            <<: *pre_spread_common_parameters
-            dash_r_files:
-                description: "space seperated paths to requirements files."
-                type: string
-                default: "${CIRCLE_PROJECT_REPONAME}/requirements.txt ${CIRCLE_PROJECT_REPONAME}/test_requirements.txt"
-            extra_pip_args:
-                description: "Any additional arguments to pip install."
-                type: string
-                default: ""
-        executor: <<parameters.executor>>
-        resource_class: <<parameters.resource_class>>
-        circleci_ip_ranges: true
-        steps:
-            - checkout
-            - utils/add_ssh_config
-            - utils/make_status_shield:
-                  status: running
-                  color: lightblue
-                  file: ~/status.svg
-                  label: <<parameters.badge_label>>
-            - utils/rsync_file:
-                  file: ~/status.svg
-                  remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
-                  host: docs
-            - steps: <<parameters.setup>>
-            - run:
-                  name: "Create cache checksum."
-                  command: |
-                      cd <<parameters.wd>>
-                      sha256sum <<parameters.dash_r_files>> > /tmp/requirements-checksum
-            - restore_cache:
-                  keys:
-                      - pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-{{ .Branch }}-{{ checksum "/tmp/requirements-checksum" }}
-                      - pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-{{ .Branch }}
-                      - pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>
-            - run:
-                  name: "Setup Python virtual environment"
-                  command: |
-                      mkdir -p logs/${CIRCLE_PROJECT_REPONAME}
-                      cd <<parameters.wd>>
-                      DASH_R_FILES_ARRAY=(<<parameters.dash_r_files>>)
-                      DASH_R_FILES=${DASH_R_FILES_ARRAY[@]/#/-r }
-                      pip install $DASH_R_FILES <<parameters.extra_pip_args>> | cat; test ${PIPESTATUS[0]} -eq 0
-                      echo "import coverage; coverage.process_startup()" > `python -c "import sys; import os; print([x for x in sys.path if x.find(os.path.expanduser('~/.venv')) != -1 and x.find('site-packages') != -1][0] + '/coverage-all-the-things.pth')"`
-            - save_cache:
-                  paths:
-                      - ~/.venv
-                  key: pip-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-{{ .Branch }}-{{ checksum "/tmp/requirements-checksum" }}
-            - setup_badass_config:
-                  wd: <<parameters.wd>>
-            - steps: <<parameters.config>>
-            - run:
-                  name: "Create pip freeze file."
-                  command: |
-                      pip freeze > <<parameters.wd>>/pip.freeze
-                  when: always
-            - persist_to_workspace:
-                  root: ~/
-                  paths:
-                      - project
-                      - .venv
     badass_test_pre_spread:
         parameters:
             <<: *pre_spread_common_parameters
-            pipenv_python_arg:
-                description: "Location or version of the python interpreter to use for pipenv."
+            python_version:
+                description: "Version of the python interpreter to use for uv."
                 type: string
                 default: ""
-            pipenv_skip_lock:
-                description: "Skip use of the pipenv lock file."
-                type: boolean
-                default: false
-            pipenv_cache_key_version:
-                description: "a string that can be changed to bust the pipenv cache."
+            venv_cache_key_version:
+                description: "a string that can be changed to bust the venv cache."
                 type: string
                 default: "1"
         executor: <<parameters.executor>>
@@ -257,21 +166,20 @@ jobs:
             - steps: <<parameters.setup>>
             - restore_cache:
                   keys:
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}
-                      - pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-main
-            - setup_pipenv:
-                  pipenv_python_arg: <<parameters.pipenv_python_arg>>
-                  pipenv_skip_lock: <<parameters.pipenv_skip_lock>>
+                      - venv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.venv_cache_key_version>>-{{ .Branch }}-{{ checksum "uv.lock" }}
+                      - venv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.venv_cache_key_version>>-{{ .Branch }}
+                      - venv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.venv_cache_key_version>>-main
+            - setup_venv:
+                  python_version: <<parameters.python_version>>
             - save_cache:
                   paths:
-                      - ~/.local/share/virtualenvs
-                  key: pipenv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.pipenv_cache_key_version>>-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+                      - ~/project/.venv/
+                  key: venv-{{ checksum "/etc/os-release" }}-<<parameters.meta_job_name>>-<<parameters.venv_cache_key_version>>-{{ .Branch }}-{{ checksum "uv.lock" }}
             - steps: <<parameters.config>>
             - persist_to_workspace:
                   root: ~/
                   paths:
-                      - .local/share/virtualenvs
+                      - project/.venv/
     badass_test_spread:
         parameters:
             repodir:
@@ -302,17 +210,13 @@ jobs:
                 type: integer
                 default: 4
             setup:
-                description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
+                description: "Any additional setup steps to run (e.g., dnf -y install foo-bar-baz)."
                 type: steps
                 default: []
             config:
                 description: "Any additional BMS configuration steps."
                 type: steps
                 default: []
-            use_pipenv:
-                description: "run commands using pipenv"
-                type: boolean
-                default: true
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         parallelism: <<parameters.parallelism>>
@@ -330,7 +234,6 @@ jobs:
                   parallel: <<parameters.parallel>>
                   test_script: <<parameters.test_script>>
                   parallelism: <<parameters.parallelism>>
-                  use_pipenv: <<parameters.use_pipenv>>
             - run:
                   name: Success flag
                   when: on_success
@@ -350,9 +253,6 @@ jobs:
                       mkdir ~/workspace
                       cp <<parameters.wd>>/*.status ~/workspace/
                       cp <<parameters.wd>>/.coverage* ~/workspace/
-                      if [ -f <<parameters.wd>>/pip.freeze ]; then
-                          cp <<parameters.wd>>/pip.freeze ~/workspace/
-                      fi
             - persist_to_workspace:
                   root: ~/
                   paths:
@@ -385,10 +285,6 @@ jobs:
                 description: "Any additional setup steps to run (e.g., yum install foo-bar-baz)."
                 type: steps
                 default: []
-            use_pipenv:
-                description: "Use pipenv to run commands."
-                type: boolean
-                default: true
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
@@ -420,18 +316,8 @@ jobs:
                   file: /tmp/status.svg
                   remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.svg
                   host: docs
-            - when:
-                  condition:
-                      not: <<parameters.use_pipenv>>
-                  steps:
-                      - utils/rsync_file:
-                            when: always
-                            file: <<parameters.wd>>/pip.freeze
-                            remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.freeze
-                            host: docs
             - coverage_combine_and_html:
                   wd: <<parameters.wd>>
-                  use_pipenv: <<parameters.use_pipenv>>
             - utils/rsync_folder:
                   when: always
                   folder: <<parameters.wd>>/htmlcov/
@@ -447,46 +333,27 @@ jobs:
                   remote_file: ${CIRCLE_BRANCH}/<<parameters.meta_job_name>>.coverage.svg
                   host: docs
 commands:
-    setup_pipenv:
-        description: "Setup pipenv."
+    setup_venv:
+        description: "Setup virtual python environment."
         parameters:
-            pipenv_python_arg:
-                description: "Location or version of the python interpreter to use for pipenv."
+            python_version:
+                description: "Version of the python interpreter to use for uv."
                 type: string
                 default: ""
-            pipenv_skip_lock:
-                description: "Skip use of the pipenv lock file."
-                type: boolean
-                default: false
         steps:
             - run:
-                  name: Install pipenv packages
+                  name: Install python packages
                   command: |
-                      mkdir -p logs/${CIRCLE_PROJECT_REPONAME}
-                      if [ "<<parameters.pipenv_python_arg>>" == "" ]; then
-                          pipenv clean
-                      else
-                          pipenv clean --python <<parameters.pipenv_python_arg>>
+                      if ! [ -x "$(command -v uv)" ]; then
+                          curl -LsSf https://astral.sh/uv/install.sh | bash
                       fi
-                      pipenv install --dev <<# parameters.pipenv_skip_lock>>--skip-lock<</ parameters.pipenv_skip_lock>>
-                      export BADASS_PIPENV_VENV="$(pipenv --venv)"
-                      echo "import sys; import os; print([x for x in sys.path if x.find(os.environ['BADASS_PIPENV_VENV']) != -1 and x.find('site-packages') != -1][0])" > get_coverage_pth_path.py
-                      export BADASS_COVERAGE_PTH_PATH="$(pipenv run python get_coverage_pth_path.py)/coverage-all-the-things.pth"
+                      mkdir -p logs/${CIRCLE_PROJECT_REPONAME}
+                      uv sync --dev <<# parameters.python_version>> --python <<parameters.python_version>> <</ parameters.python_version>>
+                      export BADASS_VENV="${HOME}/project/.venv/"
+                      echo "import sys; import os; print([x for x in sys.path if x.find(os.environ['BADASS_VENV']) != -1 and x.find('site-packages') != -1][0])" > get_coverage_pth_path.py
+                      export BADASS_COVERAGE_PTH_PATH="$(uv run python get_coverage_pth_path.py)/coverage-all-the-things.pth"
                       echo "exec('try:\n\timport tomli; import coverage; coverage.process_startup()\nexcept ImportError:\n\tpass')" > "${BADASS_COVERAGE_PTH_PATH}"
                       rm get_coverage_pth_path.py
-    setup_venv:
-        description: "Set up the Python virtual environment."
-        parameters:
-            pip_install_args:
-                description: "Any additional arguments to pip install (e.g., -r ./requirements.txt)."
-                type: string
-        steps:
-            - run:
-                  name: "Setup Python environment"
-                  command: |
-                      mkdir -p ./logs/${CIRCLE_PROJECT_REPONAME}
-                      pip install <<parameters.pip_install_args>> | cat; test ${PIPESTATUS[0]} -eq 0
-                      echo "import coverage; coverage.process_startup()" > `python -c "import sys; import os; print([x for x in sys.path if x.find(os.path.expanduser('~/.venv')) != -1 and x.find('site-packages') != -1][0] + '/coverage-all-the-things.pth')"`
     setup_badass_config:
         parameters:
             wd:
@@ -515,19 +382,18 @@ commands:
             test_script:
                 description: "The test script to run (e.g., manage.py test)."
                 type: string
-            use_pipenv:
-                description: "run commands using pipenv"
-                type: boolean
-                default: true
         steps:
             - run:
                   name: Run test suite
                   command: |
+                      if ! [ -x "$(command -v uv)" ]; then
+                          curl -LsSf https://astral.sh/uv/install.sh | bash
+                      fi
                       cd <<parameters.wd>>
                       if [ "<<parameters.parallel>>" -eq "0" ]; then
-                          <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage run -p <<parameters.test_script>>
+                          uv run coverage run -p <<parameters.test_script>>
                       else
-                          <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage run -p <<parameters.test_script>> --parallel=<<parameters.parallel>>
+                          uv run coverage run -p <<parameters.test_script>> --parallel=<<parameters.parallel>>
                       fi
     run_tests_spread:
         description: "Run the test suite, split by amount of circleci parallelism."
@@ -544,14 +410,13 @@ commands:
             parallelism:
                 description: "The level of test parallelism via circleci splitting."
                 type: integer
-            use_pipenv:
-                description: "run commands using pipenv"
-                type: boolean
-                default: true
         steps:
             - run:
                   name: Run test suite, split by amount of circleci parallelism.
                   command: |
+                      if ! [ -x "$(command -v uv)" ]; then
+                          curl -LsSf https://astral.sh/uv/install.sh | bash
+                      fi
                       cd <<parameters.wd>>
                       if [ "<<parameters.parallelism>>" -eq "1" ]; then
                           TESTFILES=""
@@ -569,9 +434,9 @@ commands:
                           TESTFILES=$(echo $TESTFILES | tr "/" "." | sed 's/.py//g')
                       fi
                       if [ "<<parameters.parallel>>" -eq "0" ]; then
-                          <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage run -p <<parameters.test_script>> $TESTFILES
+                          uv run coverage run -p <<parameters.test_script>> $TESTFILES
                       else
-                          <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage run -p <<parameters.test_script>> --parallel=<<parameters.parallel>> $TESTFILES
+                          uv run coverage run -p <<parameters.test_script>> --parallel=<<parameters.parallel>> $TESTFILES
                       fi
             - store_test_results:
                   path: test-results
@@ -588,20 +453,15 @@ commands:
                 description: "coverage percent output file name."
                 type: string
                 default: "/tmp/.coveragep"
-            use_pipenv:
-                description: "run commands using pipenv"
-                type: boolean
-                default: true
         steps:
             - run:
                   name: Combine coverage and build reports
                   command: |
-                      cd <<parameters.wd>>
-                      if ! [ -x "$(command -v coverage)" ]; then
-                          echo "Installing coverage."
-                          <<^ parameters.use_pipenv>>pip install --user coverage[toml]<</ parameters.use_pipenv>>
+                      if ! [ -x "$(command -v uv)" ]; then
+                          curl -LsSf https://astral.sh/uv/install.sh | bash
                       fi
-                      <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage combine
-                      <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage html
-                      <<# parameters.use_pipenv>>pipenv run<</ parameters.use_pipenv>> coverage report | grep -oP '^TOTAL.*\d' | awk '{print $NF}' >> <<parameters.coveragep>>
+                      cd <<parameters.wd>>
+                      uv run coverage combine
+                      uv run coverage html
+                      uv run coverage report | grep -oP '^TOTAL.*\d' | awk '{print $NF}' >> <<parameters.coveragep>>
                   when: always


### PR DESCRIPTION
This drops support for using `pipenv` and `pip`. Older projects can continue to use the previous orb until they've been transitioned.

This orb has been published as `arrai/badass@18.0.0`.