### PR TITLE
feat: allow badges to be configured via config files

### DIFF
--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -149,7 +149,7 @@ commands:
             config:
                 description: "Badge configuration. Optional JSON document to override command parameters."
                 type: string
-                default: ~/project/.circleci/status_shield.json
+                default: ~/status_shield.json
             when:
                 type: enum
                 enum: ["always", "on_success", "on_fail"]

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -115,9 +115,11 @@ commands:
             status:
                 description: "Status to set on the shield."
                 type: string
+                default: "passed"
             color:
                 description: "Color of the shield."
                 type: string
+                default: "brightgreen"
             style:
                 description: "Shield style."
                 type: enum
@@ -144,6 +146,10 @@ commands:
                 description: "Prevent any existing shield of the same name from being overwritten."
                 type: boolean
                 default: false
+            config:
+                description: "Logo configuration file. Allows configuration without specifying parameters."
+                type: string
+                default: "~/status_shield.json"
             when:
                 type: enum
                 enum: ["always", "on_success", "on_fail"]
@@ -152,8 +158,22 @@ commands:
             - run:
                   name: Make status shield (<<parameters.status>>)
                   command: |
-                      LABEL=$(echo -n "<<parameters.label>>" | sed -e 's/ /_/g' -e 's/-/--/g')
-                      <<# parameters.preserve>>[ ! -f <<parameters.file>> ] && <</ parameters.preserve>> curl -sS -o <<parameters.file>> "https://img.shields.io/badge/${LABEL}-<<parameters.status>>-<<parameters.color>>.svg?logo=<<parameters.logo>>&logoColor=white&style=<<parameters.style>>&link=${CIRCLE_BUILD_URL}" || :
+                      if [ -f <<parameters.config>> ]; then
+                          eval "export $(printf "%s\n" `cat <<parameters.config>>` | jq -r 'to_entries | map(.key |= ascii_upcase | "\(.key)=\(.value)") | @sh')"
+                      fi
+                      export COLOR=${COLOR:=<<parameters.color>>}
+                      export FILE=${FILE:=<<parameters.file>>}
+                      export LABEL=${LABEL:=<<parameters.label>>}
+                      export LABEL=${LABEL// /_}
+                      export LABEL=${LABEL//-/--}
+                      export LOGO=${LOGO:=<<parameters.logo>>}
+                      export PRESERVE=${PRESERVE:=<<parameters.preserve>>}
+                      export STATUS=${STATUS:=<<parameters.status>>}
+                      export STYLE=${STYLE:=<<parameters.style>>}
+                      if [ -f ${FILE} ] && [ "${PRESERVE}" = "true" ]; then
+                          exit 0
+                      fi
+                      curl -sS -o ${FILE} "https://img.shields.io/badge/${LABEL}-${STATUS}-${COLOR}.svg?logo=${LOGO}&logoColor=white&style=${STYLE}&link=${CIRCLE_BUILD_URL}" || :
                   when: <<parameters.when>>
     make_coverage_shield:
         description: "Fetch coverage shield from shields.io."

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -147,7 +147,7 @@ commands:
                 type: boolean
                 default: false
             config:
-                description: "Logo configuration file. Allows configuration without specifying parameters."
+                description: "Badge configuration. Optional JSON document to override command parameters."
                 type: string
                 default: "~/status_shield.json"
             when:

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -159,17 +159,23 @@ commands:
                   name: Make status shield (<<parameters.status>>)
                   command: |
                       if [ -f <<parameters.config>> ]; then
-                          eval "export $(printf "%s\n" `cat <<parameters.config>>` | jq -r 'to_entries | map(.key |= ascii_upcase | "\(.key)=\(.value)") | @sh')"
+                          COLOR=$(jq -r '.color // empty' <<parameters.config>>)
+                          FILE=$(jq -r '.file // empty' <<parameters.config>>)
+                          LABEL=$(jq -r '.label // empty' <<parameters.config>>)
+                          LOGO=$(jq -r '.logo // empty' <<parameters.config>>)
+                          PRESERVE=$(jq -r '.preserve // empty' <<parameters.config>>)
+                          STATUS=$(jq -r '.status // empty' <<parameters.config>>)
+                          STYLE=$(jq -r '.style // empty' <<parameters.config>>)
                       fi
-                      export COLOR=${COLOR:=<<parameters.color>>}
-                      export FILE=${FILE:=<<parameters.file>>}
-                      export LABEL=${LABEL:=<<parameters.label>>}
-                      export LABEL=${LABEL// /_}
-                      export LABEL=${LABEL//-/--}
-                      export LOGO=${LOGO:=<<parameters.logo>>}
-                      export PRESERVE=${PRESERVE:=<<parameters.preserve>>}
-                      export STATUS=${STATUS:=<<parameters.status>>}
-                      export STYLE=${STYLE:=<<parameters.style>>}
+                      COLOR=${COLOR:-<<parameters.color>>}
+                      FILE=${FILE:-<<parameters.file>>}
+                      LABEL=${LABEL:-<<parameters.label>>}
+                      LABEL=${LABEL// /_}
+                      LABEL=${LABEL//-/--}
+                      LOGO=${LOGO:-<<parameters.logo>>}
+                      PRESERVE=${PRESERVE:-<<parameters.preserve>>}
+                      STATUS=${STATUS:-<<parameters.status>>}
+                      STYLE=${STYLE:-<<parameters.style>>}
                       if [ -f ${FILE} ] && [ "${PRESERVE}" = "true" ]; then
                           exit 0
                       fi

--- a/orbs/utils.yml
+++ b/orbs/utils.yml
@@ -149,7 +149,7 @@ commands:
             config:
                 description: "Badge configuration. Optional JSON document to override command parameters."
                 type: string
-                default: "~/status_shield.json"
+                default: ~/project/.circleci/status_shield.json
             when:
                 type: enum
                 enum: ["always", "on_success", "on_fail"]


### PR DESCRIPTION
Add the ability to configure the badge parameters via a JSON document. The requirement for supporting this arose from the WIP to combine linting into a single job or workflow. Typically we set the parameters for the badge based on the pass/fail status of the job, but in this case, that doesn't work since the pass/fail is global on the job, but we want to generate badges based on the fail/pass of an individual step.

To simplify matters, calling the command with no parameters, generates a passing badge. This does not impact any existing use of this command.

This has been published as `arrai/utils@1.20.0` and has been tested in the https://github.com/arrai-innovations/circleci-test repo.