### PR TITLE
fix: use the appropriate labels when generating badges

### DIFF
--- a/orbs/lintinator.yml
+++ b/orbs/lintinator.yml
@@ -203,6 +203,7 @@ commands:
                             steps:
                                 - utils/make_status_shield:
                                       config: ~/eslint_status.json
+                                      label: eslint
                                       logo: eslint
                                       file: ~/eslint.svg
                                       when: always
@@ -267,6 +268,7 @@ commands:
                   steps:
                       - utils/make_status_shield:
                             config: ~/flake8_status.json
+                            label: flake8
                             logo: python
                             file: ~/flake8.svg
                             when: always
@@ -306,6 +308,7 @@ commands:
                             steps:
                                 - utils/make_status_shield:
                                       config: ~/ruff_status.json
+                                      label: ruff
                                       logo: ruff
                                       file: ~/ruff.svg
                                       when: always


### PR DESCRIPTION
The default in the `utils` orb is to just use the job name as the badge label, which generally works since we call our jobs things like `flake8` or `eslint`. That doesn't really work in this case since the job name will be static across all badges, so we need to pass in the label names ourselves.