### PR TITLE
fix: only install sentry-cli if needed

### DIFF
--- a/orbs/sentry.yml
+++ b/orbs/sentry.yml
@@ -37,7 +37,10 @@ commands:
         steps:
             - run:
                   name: Install Sentry CLI
-                  command: curl -sL https://sentry.io/get-cli/ | bash
+                  command: |
+                      if ! [ -x "$(command -v sentry-cli)" ]; then
+                          curl -sL https://sentry.io/get-cli/ | bash
+                      fi
     create_release:
         description: "Create a Sentry release and associate commits."
         parameters:


### PR DESCRIPTION
The `sentry-cli` installer emits a non-zero exit code if it's already installed, which causes jobs that call this command multiple times to blow up.