### PR TITLE
add pip-audit orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
   - [github](#github)
   - [lintinator](#lintinator)
   - [npm](#npm)
+  - [pip-audit](#pip-audit)
   - [prettier](#prettier)
   - [pypi](#pypi)
   - [pytest](#pytest)
@@ -66,6 +67,11 @@ Provides commands and jobs for running linters on projects. For information on c
 [![npm: version][]](https://circleci.com/orbs/registry/orb/arrai/npm)
 
 Provides npm utility functions. For information on available functions and configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm).
+
+### pip-audit
+[![pip-audit: version][]](https://circleci.com/orbs/registry/orb/arrai/pip-audit)
+
+Runs `pip-audit` on the project code. Supports `pip`, `pipenv`, and `uv` environments. For details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pip-audit).
 
 ### prettier
 
@@ -151,6 +157,7 @@ Once you're ready to promote your Orb to release, determine whether this counts 
 [github: version]: https://badges.circleci.com/orbs/arrai/github.svg
 [lintinator: version]: https://badges.circleci.com/orbs/arrai/lintinator.svg
 [npm: version]: https://badges.circleci.com/orbs/arrai/npm.svg
+[pip-audit: version]: https://badges.circleci.com/orbs/arrai/pip-audit.svg
 [prettier: version]: https://badges.circleci.com/orbs/arrai/prettier.svg
 [pypi: version]: https://badges.circleci.com/orbs/arrai/pypi.svg
 [pytest: version]: https://badges.circleci.com/orbs/arrai/pytest.svg

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Provides commands and jobs for running linters on projects. For information on c
 Provides npm utility functions. For information on available functions and configuration parameters, refer to the [documentation](https://circleci.com/orbs/registry/orb/arrai/npm).
 
 ### pip-audit
+
 [![pip-audit: version][]](https://circleci.com/orbs/registry/orb/arrai/pip-audit)
 
 Runs `pip-audit` on the project code. Supports `pip`, `pipenv`, and `uv` environments. For details, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pip-audit).
@@ -169,4 +170,3 @@ Once you're ready to promote your Orb to release, determine whether this counts 
 [`vueda-server`]: https://github.com/arrai-innovations/vueda-server
 [`vueda-client`]: https://github.com/arrai-innovations/vueda-client
 [`vueda-deployer`]: https://github.com/arrai-innovations/vueda-deployer
-

--- a/orbs/pip-audit.yml
+++ b/orbs/pip-audit.yml
@@ -1,0 +1,119 @@
+version: 2.1
+orbs:
+    utils: arrai/utils@1.21.1
+executors:
+    python313:
+        docker:
+            - image: cimg/python:3.13
+    python312:
+        docker:
+            - image: cimg/python:3.12
+    python311:
+        docker:
+            - image: cimg/python:3.11
+    python310:
+        docker:
+            - image: cimg/python:3.10
+    python39:
+        docker:
+            - image: cimg/python:3.9
+aliases:
+    common_parameters: &common_parameters
+        executor:
+            description: "The executor to use for the job."
+            type: executor
+            default: python313
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        config:
+            description: "Any additional configuration steps."
+            type: steps
+            default: []
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+        env_type:
+            description: "Python environment type."
+            type: enum
+            default: "pipenv"
+            enum: [pip, pipenv, uv]
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+            default: true
+        ignored_vulnerabilities:
+            description: "Space separated list of ignored vulnerabilities, e.g. 'CVE-2025-27516'"
+            type: string
+            default: ""
+    common_steps: &common_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - run:
+              name: Install requirements
+              command: |
+                  if [ "<<parameters.env_type>>" != "uv" ]; then
+                      pip install --upgrade pip-audit pipenv
+                  else
+                      if ! [ -x "$(command -v uv)" ]; then
+                          curl -LsSf https://astral.sh/uv/install.sh | bash
+                      else
+                          uv self update
+                      fi
+                  fi
+        - steps: <<parameters.config>>
+        - run:
+              name: Run pip-audit
+              command: |
+                  IGNORES=(<<parameters.ignored_vulnerabilities>>)
+                  ARGS=("${IGNORES[@]/#/--ignore-vuln }")
+                  if [ "<<parameters.env_type>>" = "pip" ]; then
+                      pip-audit --aliases -r requirements.txt ${ARGS[@]}
+                  elif [ "<<parameters.env_type>>" == "pipenv" ]; then
+                      pip-audit --aliases -r <(pipenv requirements) ${ARGS[@]}
+                  elif [ "<<parameters.env_type>>" == "uv" ]; then
+                      uv export --locked --quiet --format requirements-txt --no-editable | sed -e '/^.$/d' > /tmp/requirements.txt
+                      uvx pip-audit --aliases -r /tmp/requirements.txt --disable-pip ${ARGS[@]}
+                  fi
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - utils/add_ssh_config
+                  - utils/rsync_install
+                  - utils/make_status_shield:
+                        when: on_fail
+                        status: errors
+                        color: red
+                        logo: python
+                  - utils/make_status_shield:
+                        when: on_success
+                        status: passed
+                        color: brightgreen
+                        logo: python
+                  - utils/rsync_file:
+                        when: always
+                        file: ~/status.svg
+                        remote_file: ${CIRCLE_BRANCH}/${CIRCLE_JOB}.svg
+                        host: docs
+jobs:
+    pip_audit:
+        parameters:
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        environment:
+            PIP_AUDIT_PROGRESS_SPINNER: "off"
+        steps: *common_steps
+    pip_audit_ip:
+        parameters:
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        environment:
+            PIP_AUDIT_PROGRESS_SPINNER: "off"
+        steps: *common_steps


### PR DESCRIPTION
Published as `arrai/pip-audit@1.0.0`

This serves as a replacement for the `arrai/safety` orb. Safety's licensing changes make it unsuitable for running in CI/CD pipelines. As `pipenv check` uses `safety` behind the scenes, newer releases suffer from the same problem. `uv` does not currently have a native audit system.

This  supports three environment types: plain `pip` via a `requirements.txt`, `pipenv`, and `uv`. 