### PR TITLE
feat: add pysentry job orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ _Note to contributors_: The Orb Registry is public; private data should be passe
   - [pip-audit](#pip-audit)
   - [prettier](#prettier)
   - [pypi](#pypi)
+  - [pysentry](#pysentry)
   - [pytest](#pytest)
   - [ruff](#ruff)
   - [safety](#safety)
@@ -87,6 +88,11 @@ Provides functionality for running prettier on project code. For more details, r
 Publishes python packages to a PyPI (or compatible) server. It does not include the build step. It is assumed that some other job builds the packages and stashes the dist folder in a cache. Refer to the [example configuration](/examples/pypi.yml) on how this might look.
 
 For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pypi).
+
+### pysentry
+[![pysentry: version][]](https://circleci.com/orbs/registry/orb/arrai/pysentry)
+
+Runs `pysentry` on the project code. Audit configuration is assumed to live in the project's `pyproject.toml` or `.pysentry.toml`. For information on job configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pysentry).
 
 ### pytest
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Publishes python packages to a PyPI (or compatible) server. It does not include 
 For information on configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pypi).
 
 ### pysentry
+
 [![pysentry: version][]](https://circleci.com/orbs/registry/orb/arrai/pysentry)
 
 Runs `pysentry` on the project code. Audit configuration is assumed to live in the project's `pyproject.toml` or `.pysentry.toml`. For information on job configuration parameters, refer to the generated [documentation](https://circleci.com/orbs/registry/orb/arrai/pysentry).
@@ -167,6 +168,7 @@ Once you're ready to promote your Orb to release, determine whether this counts 
 [pip-audit: version]: https://badges.circleci.com/orbs/arrai/pip-audit.svg
 [prettier: version]: https://badges.circleci.com/orbs/arrai/prettier.svg
 [pypi: version]: https://badges.circleci.com/orbs/arrai/pypi.svg
+[pysentry: version]: https://badges.circleci.com/orbs/arrai/pysentry.svg
 [pytest: version]: https://badges.circleci.com/orbs/arrai/pytest.svg
 [ruff: version]: https://badges.circleci.com/orbs/arrai/ruff.svg
 [safety: version]: https://badges.circleci.com/orbs/arrai/safety.svg

--- a/orbs/pysentry.yml
+++ b/orbs/pysentry.yml
@@ -34,6 +34,9 @@ aliases:
         - run:
               name: Run pysentry
               command: |
+                  if ! [ -x "$(command -v uv)" ]; then
+                      curl -LsSf https://astral.sh/uv/install.sh | bash
+                  fi
                   uvx pysentry-rs==<<parameters.version>>
         - when:
               condition: <<parameters.create_badges>>

--- a/orbs/pysentry.yml
+++ b/orbs/pysentry.yml
@@ -1,0 +1,76 @@
+version: 2.1
+orbs:
+    utils: arrai/utils@1.21.2
+executors:
+    python:
+        docker:
+            - image: cimg/python:3.14
+aliases:
+    common_parameters: &common_parameters
+        executor:
+            description: "The executor to use for the job."
+            type: executor
+            default: python
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        config:
+            description: "Any additional configuration steps."
+            type: steps
+            default: []
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+        create_badges:
+            description: "Generate badges."
+            type: boolean
+            default: true
+        version:
+            description: "PySentry release."
+            type: string
+            default: 0.4.3
+    common_steps: &common_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - run:
+              name: Run pysentry
+              command: |
+                  uvx pysentry-rs==<<parameters.version>>
+        - when:
+              condition: <<parameters.create_badges>>
+              steps:
+                  - utils/add_ssh_config
+                  - utils/rsync_install
+                  - utils/make_status_shield:
+                        when: on_fail
+                        status: errors
+                        color: red
+                        logo: python
+                  - utils/make_status_shield:
+                        when: on_success
+                        status: passed
+                        color: brightgreen
+                        logo: python
+                  - utils/rsync_file:
+                        when: always
+                        file: ~/status.svg
+                        remote_file: ${CIRCLE_BRANCH}/${CIRCLE_JOB}.svg
+                        host: docs
+jobs:
+    pysentry:
+        parameters:
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: false
+        steps: *common_steps
+    pysentry_ip:
+        parameters:
+            <<: *common_parameters
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps: *common_steps

--- a/orbs/pysentry.yml
+++ b/orbs/pysentry.yml
@@ -16,10 +16,6 @@ aliases:
             type: enum
             enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
             default: small
-        config:
-            description: "Any additional configuration steps."
-            type: steps
-            default: []
         setup:
             description: "Any additional setup steps."
             type: steps


### PR DESCRIPTION
New orb to support using `pysentry` as a package audit tool for python projects.  It supports most of the common package manager formats out of the box; crucially for us, `uv.lock`, which makes this a lot simpler to use than `pip-audit`. Audit config, including ignored vulns, can be set in the project's `pyproject.toml`.