### PR TITLE
feat: switch to trusted publishing via oidc

### DIFF
--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.18.0
+    utils: arrai/utils@1.21.2
 executors:
     lts:
         environment:
@@ -255,4 +255,5 @@ jobs:
             - run:
                   name: "Publish to npm"
                   command: |
+                      export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
                       npm publish


### PR DESCRIPTION
Based on the instructions @ https://docs.npmjs.com/trusted-publishers#circleci-configuration.
Setting `NPM_ID_TOKEN` in the environment supersedes the token set in the `~/.npmrc` file, which is handy since we might need the token in there to be able to read from the private registry during install.