### PR TITLE
feat(npm): support token auth to non-npmjs registries in publish job

### DIFF
--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -13,6 +13,19 @@ executors:
         docker:
             - image: cimg/node:current
 aliases:
+    common_npm_config_parameters: &common_npm_config_parameters
+        registry:
+            description: "The npm registry to authenticate against."
+            type: string
+            default: "registry.npmjs.org"
+        token:
+            description: "Auth token for the registry."
+            type: string
+            default: ${NPM_TOKEN}
+        scopes:
+            description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
+            type: string
+            default: ""
     common_audit_parameters: &common_audit_parameters
         wd:
             type: string
@@ -59,7 +72,10 @@ aliases:
         - steps: <<parameters.setup>>
         - utils/upgrade_npm:
               version: <<parameters.npm_version>>
-        - utils/add_npm_config
+        - utils/add_npm_config:
+              registry: <<parameters.registry>>
+              token: <<parameters.token>>
+              scopes: <<parameters.scopes>>
         - steps: <<parameters.config>>
         - run:
               name: "Run npm audit"
@@ -111,7 +127,7 @@ aliases:
 jobs:
     audit:
         parameters:
-            <<: *common_audit_parameters
+            <<: [*common_audit_parameters, *common_npm_config_parameters]
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: false
@@ -119,13 +135,14 @@ jobs:
 
     audit_fixed_ip:
         parameters:
-            <<: *common_audit_parameters
+            <<: [*common_audit_parameters, *common_npm_config_parameters]
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
         steps: *common_audit_steps
     coverage:
         parameters:
+            <<: *common_npm_config_parameters
             wd:
                 type: string
                 default: ~/project
@@ -166,7 +183,10 @@ jobs:
             - steps: <<parameters.setup>>
             - utils/upgrade_npm:
                   version: <<parameters.npm_version>>
-            - utils/add_npm_config
+            - utils/add_npm_config:
+                  registry: <<parameters.registry>>
+                  token: <<parameters.token>>
+                  scopes: <<parameters.scopes>>
             - run:
                   name: "Install Packages"
                   command: |
@@ -216,6 +236,7 @@ jobs:
                             host: docs
     publish:
         parameters:
+            <<: *common_npm_config_parameters
             wd:
                 type: string
                 default: ~/project
@@ -243,18 +264,6 @@ jobs:
                 description: "Publish via CircleCI OIDC trusted publishing. Only supported by npmjs.org; set to false to authenticate to another registry with a token."
                 type: boolean
                 default: true
-            registry:
-                description: "The npm registry to authenticate against."
-                type: string
-                default: "registry.npmjs.org"
-            token:
-                description: "Auth token for the registry. Used when oidc is false."
-                type: string
-                default: ${NPM_TOKEN}
-            scopes:
-                description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
-                type: string
-                default: ""
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         steps:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.21.2
+    utils: arrai/utils@1.22.0
 executors:
     lts:
         environment:
@@ -239,6 +239,22 @@ jobs:
                 description: "NPM version to use"
                 type: string
                 default: "latest"
+            oidc:
+                description: "Publish via CircleCI OIDC trusted publishing. Only supported by npmjs.org; set to false to authenticate to another registry with a token."
+                type: boolean
+                default: true
+            registry:
+                description: "The npm registry to authenticate against."
+                type: string
+                default: "registry.npmjs.org"
+            token:
+                description: "Auth token for the registry. Used when oidc is false."
+                type: string
+                default: ${NPM_TOKEN}
+            scopes:
+                description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
+                type: string
+                default: ""
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         steps:
@@ -246,14 +262,28 @@ jobs:
             - steps: <<parameters.setup>>
             - utils/upgrade_npm:
                   version: <<parameters.npm_version>>
-            - utils/add_npm_config
+            - utils/add_npm_config:
+                  registry: <<parameters.registry>>
+                  token: <<parameters.token>>
+                  scopes: <<parameters.scopes>>
             - run:
                   name: "Install Packages"
                   command: |
                       npm ci
             - steps: <<parameters.config>>
-            - run:
-                  name: "Publish to npm"
-                  command: |
-                      export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
-                      npm publish
+            - when:
+                  condition: <<parameters.oidc>>
+                  steps:
+                      - run:
+                            name: "Publish to npm"
+                            command: |
+                                export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:<<parameters.registry>>"}')
+                                npm publish
+            - when:
+                  condition:
+                      not: <<parameters.oidc>>
+                  steps:
+                      - run:
+                            name: "Publish to npm"
+                            command: |
+                                npm publish


### PR DESCRIPTION
Add oidc/registry/token/scopes params to npm/publish so packages can be published to private registries (e.g. npm.arrai.dev) via token auth. Defaults keep OIDC trusted publishing to npmjs.org unchanged. Bump utils to 1.22.0 for scoped .npmrc support.