### PR TITLE
feat: make npm registry/token/scopes configurable across all orbs

### DIFF
--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.18.0
+    utils: arrai/utils@1.22.0
 aliases:
     common_parameters: &common_parameters
         wd:
@@ -40,12 +40,27 @@ aliases:
             description: "Run npm install prior to lintint"
             type: boolean
             default: true
+        npm_registry:
+            description: "The npm registry to authenticate against."
+            type: string
+            default: "registry.npmjs.org"
+        npm_token:
+            description: "Auth token for the registry."
+            type: string
+            default: ${NPM_TOKEN}
+        npm_scopes:
+            description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
+            type: string
+            default: ""
     common_steps: &common_steps
         - checkout
         - steps: <<parameters.setup>>
         - utils/upgrade_npm:
               version: <<parameters.npm_version>>
-        - utils/add_npm_config
+        - utils/add_npm_config:
+              registry: <<parameters.npm_registry>>
+              token: <<parameters.npm_token>>
+              scopes: <<parameters.npm_scopes>>
         - steps: <<parameters.config>>
         - when:
               condition: <<parameters.npm_install>>

--- a/orbs/lintinator.yml
+++ b/orbs/lintinator.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.21.2
+    utils: arrai/utils@1.22.0
 executors:
     python314:
         docker:
@@ -27,6 +27,19 @@ executors:
         docker:
             - image: cimg/node:lts
 aliases:
+    common_npm_config_parameters: &common_npm_config_parameters
+        npm_registry:
+            description: "The npm registry to authenticate against."
+            type: string
+            default: "registry.npmjs.org"
+        npm_token:
+            description: "Auth token for the registry."
+            type: string
+            default: ${NPM_TOKEN}
+        npm_scopes:
+            description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
+            type: string
+            default: ""
     common_node_parameters: &common_node_parameters
         hooks:
             description: List of linters to run
@@ -82,9 +95,12 @@ commands:
     run_node_linters:
         description: Run linters using npx
         parameters:
-            <<: *common_node_parameters
+            <<: [*common_node_parameters, *common_npm_config_parameters]
         steps:
-            - utils/add_npm_config
+            - utils/add_npm_config:
+                  registry: <<parameters.npm_registry>>
+                  token: <<parameters.npm_token>>
+                  scopes: <<parameters.npm_scopes>>
             - run:
                   name: Install node packages
                   when: always
@@ -171,7 +187,7 @@ commands:
     run_python_linters:
         description: Run linters using hook manager (pre-commit or lefthook)
         parameters:
-            <<: *common_lint_parameters
+            <<: [*common_lint_parameters, *common_npm_config_parameters]
         steps:
             - run:
                   name: Install pre-commit
@@ -218,7 +234,10 @@ commands:
                                       pattern: '.*\beslint\b.*'
                                       value: <<parameters.hooks>>
                   steps:
-                      - utils/add_npm_config
+                      - utils/add_npm_config:
+                            registry: <<parameters.npm_registry>>
+                            token: <<parameters.npm_token>>
+                            scopes: <<parameters.npm_scopes>>
                       - run:
                             name: Install node packages
                             when: always
@@ -461,7 +480,7 @@ commands:
 jobs:
     lint_python:
         parameters:
-            <<: *common_lint_parameters
+            <<: [*common_lint_parameters, *common_npm_config_parameters]
             executor:
                 description: The executor to use for the job
                 type: executor
@@ -477,7 +496,7 @@ jobs:
         steps: *common_lint_steps
     lint_python_fixed_ip:
         parameters:
-            <<: *common_lint_parameters
+            <<: [*common_lint_parameters, *common_npm_config_parameters]
             executor:
                 description: The executor to use for the job
                 type: executor
@@ -493,7 +512,7 @@ jobs:
         steps: *common_lint_steps
     lint_node:
         parameters:
-            <<: *common_node_parameters
+            <<: [*common_node_parameters, *common_npm_config_parameters]
             executor:
                 description: The executor to use for the job
                 type: executor
@@ -509,7 +528,7 @@ jobs:
         steps: *common_node_steps
     lint_node_fixed_ip:
         parameters:
-            <<: *common_node_parameters
+            <<: [*common_node_parameters, *common_npm_config_parameters]
             executor:
                 description: The executor to use for the job
                 type: executor

--- a/orbs/pnpm.yml
+++ b/orbs/pnpm.yml
@@ -16,6 +16,20 @@ executors:
             - image: cimg/node:lts
 
 aliases:
+    common_npm_config_parameters: &common_npm_config_parameters
+        npm_registry:
+            description: "The npm registry to authenticate against."
+            type: string
+            default: "registry.npmjs.org"
+        npm_token:
+            description: "Auth token for the registry."
+            type: string
+            default: ${NPM_TOKEN}
+        npm_scopes:
+            description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
+            type: string
+            default: ""
+
     common_audit_parameters: &common_audit_parameters
         wd:
             description: "Directory to run pnpm audit from. For a pnpm workspace, leave at the repo root to audit all packages."
@@ -50,7 +64,10 @@ aliases:
         - checkout
         - steps: <<parameters.setup>>
         - install_pnpm
-        - utils/add_npm_config
+        - utils/add_npm_config:
+              registry: <<parameters.npm_registry>>
+              token: <<parameters.npm_token>>
+              scopes: <<parameters.npm_scopes>>
         - steps: <<parameters.config>>
         - run:
               name: "Run pnpm audit."
@@ -96,7 +113,7 @@ commands:
 jobs:
     audit:
         parameters:
-            <<: *common_audit_parameters
+            <<: [*common_audit_parameters, *common_npm_config_parameters]
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: false
@@ -104,7 +121,7 @@ jobs:
 
     audit_fixed_ip:
         parameters:
-            <<: *common_audit_parameters
+            <<: [*common_audit_parameters, *common_npm_config_parameters]
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
@@ -112,6 +129,7 @@ jobs:
 
     publish:
         parameters:
+            <<: *common_npm_config_parameters
             wd:
                 description: "Directory of the package to publish. In a pnpm workspace, set this to the package subdir; pnpm install always runs at the repo root so the workspace resolves correctly."
                 type: string
@@ -134,7 +152,10 @@ jobs:
             - checkout
             - steps: <<parameters.setup>>
             - install_pnpm
-            - utils/add_npm_config
+            - utils/add_npm_config:
+                  registry: <<parameters.npm_registry>>
+                  token: <<parameters.npm_token>>
+                  scopes: <<parameters.npm_scopes>>
             - run:
                   name: "Install Packages."
                   command: pnpm install --frozen-lockfile

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.18.0
+    utils: arrai/utils@1.22.0
 executors:
     node:
         environment:
@@ -38,10 +38,25 @@ aliases:
             description: "Generate badges."
             type: boolean
             default: true
+        npm_registry:
+            description: "The npm registry to authenticate against."
+            type: string
+            default: "registry.npmjs.org"
+        npm_token:
+            description: "Auth token for the registry."
+            type: string
+            default: ${NPM_TOKEN}
+        npm_scopes:
+            description: "Newline separated scope-to-registry mappings to add to .npmrc (e.g. @arrai-innovations:registry=https://npm.arrai.dev/)."
+            type: string
+            default: ""
     common_steps: &common_steps
         - checkout
         - steps: <<parameters.setup>>
-        - utils/add_npm_config
+        - utils/add_npm_config:
+              registry: <<parameters.npm_registry>>
+              token: <<parameters.npm_token>>
+              scopes: <<parameters.npm_scopes>>
         - steps: <<parameters.config>>
         - run:
               name: Install prettier


### PR DESCRIPTION
Add the ability to configure the npm registry, auth token, and scopes to all the orbs that use `add_npm_config` from the `utils` orb.