### PR TITLE
feat: add job to allow npm publish using fixed ip ranges

### DIFF
--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -67,6 +67,34 @@ aliases:
             description: "NPM version to use"
             type: string
             default: "latest"
+    common_publish_parameters: &common_publish_parameters
+            wd:
+                type: string
+                default: ~/project
+            executor:
+                type: executor
+                default: lts
+            resource_class:
+                description: "The resource class to use for the job."
+                type: enum
+                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+                default: small
+            setup:
+                description: "Any additional setup steps."
+                type: steps
+                default: []
+            config:
+                description: "Any additional configuration steps."
+                type: steps
+                default: []
+            npm_version:
+                description: "NPM version to use"
+                type: string
+                default: "latest"
+            oidc:
+                description: "Publish via CircleCI OIDC trusted publishing. Only supported by npmjs.org; set to false to authenticate to another registry with a token."
+                type: boolean
+                default: true
     common_audit_steps: &common_audit_steps
         - checkout
         - steps: <<parameters.setup>>
@@ -124,6 +152,35 @@ aliases:
                         file: ~/status.svg
                         remote_file: ${CIRCLE_BRANCH}/npm-audit.svg
                         host: docs
+    common_publish_steps: &common_publish_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - utils/upgrade_npm:
+              version: <<parameters.npm_version>>
+        - utils/add_npm_config:
+              registry: <<parameters.registry>>
+              token: <<parameters.token>>
+              scopes: <<parameters.scopes>>
+        - run:
+              name: "Install Packages"
+              command: npm ci
+        - steps: <<parameters.config>>
+        - when:
+              condition: <<parameters.oidc>>
+              steps:
+                  - run:
+                        name: "Publish to npm"
+                        command: |
+                            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:<<parameters.registry>>"}')
+                            npm publish
+        - when:
+              condition:
+                  not: <<parameters.oidc>>
+              steps:
+                  - run:
+                        name: "Publish to npm"
+                        command: npm publish
+
 jobs:
     audit:
         parameters:
@@ -140,6 +197,7 @@ jobs:
         resource_class: <<parameters.resource_class>>
         circleci_ip_ranges: true
         steps: *common_audit_steps
+
     coverage:
         parameters:
             <<: *common_npm_config_parameters
@@ -236,63 +294,15 @@ jobs:
                             host: docs
     publish:
         parameters:
-            <<: *common_npm_config_parameters
-            wd:
-                type: string
-                default: ~/project
-            executor:
-                type: executor
-                default: lts
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
-            config:
-                description: "Any additional configuration steps."
-                type: steps
-                default: []
-            npm_version:
-                description: "NPM version to use"
-                type: string
-                default: "latest"
-            oidc:
-                description: "Publish via CircleCI OIDC trusted publishing. Only supported by npmjs.org; set to false to authenticate to another registry with a token."
-                type: boolean
-                default: true
+            <<: [*common_npm_config_parameters, *common_publish_parameters]
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - utils/upgrade_npm:
-                  version: <<parameters.npm_version>>
-            - utils/add_npm_config:
-                  registry: <<parameters.registry>>
-                  token: <<parameters.token>>
-                  scopes: <<parameters.scopes>>
-            - run:
-                  name: "Install Packages"
-                  command: |
-                      npm ci
-            - steps: <<parameters.config>>
-            - when:
-                  condition: <<parameters.oidc>>
-                  steps:
-                      - run:
-                            name: "Publish to npm"
-                            command: |
-                                export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:<<parameters.registry>>"}')
-                                npm publish
-            - when:
-                  condition:
-                      not: <<parameters.oidc>>
-                  steps:
-                      - run:
-                            name: "Publish to npm"
-                            command: |
-                                npm publish
+        steps: *common_publish_steps
+
+    publish_fixed_ip:
+        parameters:
+            <<: [*common_npm_config_parameters, *common_publish_parameters]
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps: *common_publish_steps


### PR DESCRIPTION
Created a copy of `publish` as `publish_fixed_ip` that sets `circleci_ip_ranges` as this is needed to publish to our self-hosted npm registry.