### PR TITLE
fix: drop corepack wrapper for pnpm (lintinator + pnpm orbs)

### DIFF
--- a/orbs/lintinator.yml
+++ b/orbs/lintinator.yml
@@ -207,7 +207,10 @@ commands:
                                   fi
                                   uv sync --frozen --only-group dev
                               fi
-                              corepack pnpm install
+                              if ! [ -x "$(command -v pnpm)" ]; then
+                                  npm install -g pnpm
+                              fi
+                              pnpm install
                           fi
                       fi
             - when:
@@ -261,7 +264,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run prettier --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands prettier --all-files
+                                    pnpm exec lefthook run pre-commit --commands prettier --all-files
                                 fi
             - when:
                   condition:
@@ -276,7 +279,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run black --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands black --all-files
+                                    pnpm exec lefthook run pre-commit --commands black --all-files
                                 fi
             - when:
                   condition:
@@ -292,7 +295,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run eslint --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands eslint --all-files
+                                    pnpm exec lefthook run pre-commit --commands eslint --all-files
                                 fi
                                 if [ $? -ne 0 ]; then
                                     echo '{"color": "red", "status": "errors"}' > ~/eslint_status.json
@@ -325,7 +328,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run md-toc --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands md-toc --all-files
+                                    pnpm exec lefthook run pre-commit --commands md-toc --all-files
                                 fi
             - when:
                   condition:
@@ -341,7 +344,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run flake8 --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands flake8 --all-files
+                                    pnpm exec lefthook run pre-commit --commands flake8 --all-files
                                 fi
                                 if [ $? -ne 0 ]; then
                                     echo '{"color": "red", "status": "errors"}' > ~/flake8_status.json
@@ -361,7 +364,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run pyproject-flake8 --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands pyproject-flake8 --all-files
+                                    pnpm exec lefthook run pre-commit --commands pyproject-flake8 --all-files
                                 fi
                                 if [ $? -ne 0 ]; then
                                     echo '{"color": "red", "status": "errors"}' > ~/flake8_status.json
@@ -400,7 +403,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run ruff-check --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands ruff-check --all-files
+                                    pnpm exec lefthook run pre-commit --commands ruff-check --all-files
                                 fi
                                 if [ $? -ne 0 ]; then
                                     echo '{"color": "red", "status": "errors"}' > ~/ruff_status.json
@@ -414,7 +417,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run ruff-format --all-files
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands ruff-format --all-files
+                                    pnpm exec lefthook run pre-commit --commands ruff-format --all-files
                                 fi
                                 if [ $? -ne 0 ]; then
                                     echo '{"color": "red", "status": "errors"}' > ~/ruff_status.json
@@ -448,7 +451,7 @@ commands:
                                 if [ "<<parameters.hook_manager>>" = "pre-commit" ]; then
                                     pre-commit run biome-check --all-files | tee ~/biome.log
                                 elif [ "<<parameters.hook_manager>>" = "lefthook" ]; then
-                                    corepack pnpm exec lefthook run pre-commit --commands biome-check --all-files | tee ~/biome.log
+                                    pnpm exec lefthook run pre-commit --commands biome-check --all-files | tee ~/biome.log
                                 fi
                                 if [ $? -ne 0 ]; then
                                     if grep -q "Found .* errors" ~/biome.log; then

--- a/orbs/pnpm.yml
+++ b/orbs/pnpm.yml
@@ -102,11 +102,7 @@ commands:
                   name: "Install pnpm."
                   command: |
                       if ! [ -x "$(command -v pnpm)" ]; then
-                          mkdir -p "$HOME/.local/bin"
-                          printf '%s\n' '#!/usr/bin/env bash' 'exec corepack pnpm "$@"' > "$HOME/.local/bin/pnpm"
-                          chmod +x "$HOME/.local/bin/pnpm"
-                          echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
-                          export PATH="$HOME/.local/bin:$PATH"
+                          npm install -g pnpm
                       fi
                       pnpm --version
 


### PR DESCRIPTION
Both orbs invoked pnpm through corepack (`lintinator` via `corepack pnpm ...`, `pnpm` via a `~/.local/bin/pnpm` shim that exec'd `corepack pnpm`).

Corepack selects the pnpm version from the project's `packageManager` field and, by design, refuses to let pnpm self-switch to a different version. When a project's `packageManager` and `devEngines.packageManager` disagree, recent pnpm errors out loudly rather than running the "wrong" version.

This drops corepack from both orbs and calls the standalone pnpm launcher directly, so pnpm self-manages the project-pinned version. If pnpm isn't already on `PATH`, it's installed with `npm install -g pnpm`.

## Changes
- `lintinator`: `corepack pnpm` -> `pnpm` in the lefthook path (install + all hook runners), with a guard to install pnpm if missing.
- `pnpm`: `install_pnpm` installs standalone pnpm instead of writing a `corepack pnpm` shim.

## Testing
Dev orbs published and exercised in a downstream repo:
- `arrai/lintinator@dev:no-corepack`
- `arrai/pnpm@dev:no-corepack`
