### PR TITLE
feat: allow pnpm publishing from fixed ip ranges

### DIFF
--- a/orbs/pnpm.yml
+++ b/orbs/pnpm.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    utils: arrai/utils@1.22.0
+    utils: arrai/utils@1.23.0
 
 executors:
     current:
@@ -60,6 +60,24 @@ aliases:
             type: boolean
             default: true
 
+    common_publish_parameters: &common_publish_parameters
+        wd:
+            description: "Directory of the package to publish. In a pnpm workspace, set this to the package subdir; pnpm install always runs at the repo root so the workspace resolves correctly."
+            type: string
+            default: ~/project
+        executor:
+            type: executor
+            default: lts
+        resource_class:
+            description: "The resource class to use for the job."
+            type: enum
+            enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
+            default: small
+        setup:
+            description: "Any additional setup steps."
+            type: steps
+            default: []
+
     common_audit_steps: &common_audit_steps
         - checkout
         - steps: <<parameters.setup>>
@@ -94,6 +112,23 @@ aliases:
                         remote_file: ${CIRCLE_BRANCH}/pnpm-audit.svg
                         host: docs
 
+    common_publish_steps: &common_publish_steps
+        - checkout
+        - steps: <<parameters.setup>>
+        - install_pnpm
+        - utils/add_npm_config:
+              registry: <<parameters.npm_registry>>
+              token: <<parameters.npm_token>>
+              scopes: <<parameters.npm_scopes>>
+        - run:
+              name: "Install Packages."
+              command: pnpm install --frozen-lockfile
+        - run:
+              name: "Publish to npm."
+              command: |
+                  cd <<parameters.wd>>
+                  pnpm publish --no-git-checks
+
 commands:
     install_pnpm:
         description: "Ensure pnpm is installed."
@@ -125,38 +160,15 @@ jobs:
 
     publish:
         parameters:
-            <<: *common_npm_config_parameters
-            wd:
-                description: "Directory of the package to publish. In a pnpm workspace, set this to the package subdir; pnpm install always runs at the repo root so the workspace resolves correctly."
-                type: string
-                default: ~/project
-            executor:
-                type: executor
-                default: lts
-            resource_class:
-                description: "The resource class to use for the job."
-                type: enum
-                enum: [small, medium, medium+, large, xlarge, 2xlarge, 2xlarge+]
-                default: small
-            setup:
-                description: "Any additional setup steps."
-                type: steps
-                default: []
+            <<: [*common_npm_config_parameters, *common_publish_parameters]
         executor: <<parameters.executor>>
         resource_class: <<parameters.resource_class>>
-        steps:
-            - checkout
-            - steps: <<parameters.setup>>
-            - install_pnpm
-            - utils/add_npm_config:
-                  registry: <<parameters.npm_registry>>
-                  token: <<parameters.npm_token>>
-                  scopes: <<parameters.npm_scopes>>
-            - run:
-                  name: "Install Packages."
-                  command: pnpm install --frozen-lockfile
-            - run:
-                  name: "Publish to npm."
-                  command: |
-                      cd <<parameters.wd>>
-                      pnpm publish --no-git-checks
+        steps: *common_publish_steps
+
+    publish_fixed_ip:
+        parameters:
+            <<: [*common_npm_config_parameters, *common_publish_parameters]
+        executor: <<parameters.executor>>
+        resource_class: <<parameters.resource_class>>
+        circleci_ip_ranges: true
+        steps: *common_publish_steps


### PR DESCRIPTION
Added `publish_fixed_ip` command to allow publishing via CircleCI's fixed IP ranges. This brings feature parity with the npm orb, which already had this feature.