### PR TITLE
chore: bump utils orb for orbs calling add_npm_config

### DIFF
--- a/orbs/eslint.yml
+++ b/orbs/eslint.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.22.0
+    utils: arrai/utils@1.23.1
 aliases:
     common_parameters: &common_parameters
         wd:

--- a/orbs/lintinator.yml
+++ b/orbs/lintinator.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.22.0
+    utils: arrai/utils@1.23.1
 executors:
     python314:
         docker:

--- a/orbs/npm.yml
+++ b/orbs/npm.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.22.0
+    utils: arrai/utils@1.23.1
 executors:
     lts:
         environment:

--- a/orbs/pnpm.yml
+++ b/orbs/pnpm.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-    utils: arrai/utils@1.23.0
+    utils: arrai/utils@1.23.1
 
 executors:
     current:

--- a/orbs/prettier.yml
+++ b/orbs/prettier.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    utils: arrai/utils@1.22.0
+    utils: arrai/utils@1.23.1
 executors:
     node:
         environment:


### PR DESCRIPTION
Orbs call `add_npm_config` need to get bumped to the latest `utils` release.